### PR TITLE
chore: harden default linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,41 +1,19 @@
 version: "2"
 linters:
-  enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - contextcheck
-    - durationcheck
-    - errchkjson
-    - errorlint
-    - exhaustive
-    - gocheckcompilerdirectives
-    - gochecksumtype
-    - goconst
-    - gocritic
-    - gocyclo
-    - gosec
-    - gosmopolitan
-    - loggercheck
-    - makezero
-    - misspell
-    - musttag
-    - nakedret
-    - nilerr
-    - nilnesserr
-    - noctx
-    - prealloc
-    - protogetter
-    - reassign
-    - recvcheck
-    - rowserrcheck
-    - spancheck
-    - sqlclosecheck
-    - testifylint
-    - unconvert
-    - unparam
-    - zerologlint
+  default: all
+  disable:
+    - depguard
+    - err113
+    - exhaustruct
+    - gochecknoglobals
+    - gochecknoinits
+    - ireturn
+    - lll
+    - nonamedreturns
+    - revive
+    - testpackage
+    - wrapcheck
+    - wsl
   settings:
     dupl:
       threshold: 100
@@ -71,12 +49,16 @@ linters:
     generated: lax
     rules:
       - linters:
+          - containedctx
+          - cyclop
           - dupl
           - errcheck
           - exportloopref
+          - funlen
           - gocyclo
           - gosec
           - unparam
+          - varnamelen
         path: _test(ing)?\.go
       - linters:
           - gocritic

--- a/apis/instance/v1alpha1/groupversion_info.go
+++ b/apis/instance/v1alpha1/groupversion_info.go
@@ -32,9 +32,9 @@ const (
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
+	// SchemeGroupVersion is group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 )

--- a/apis/instance/v1alpha1/qualitygate_types.go
+++ b/apis/instance/v1alpha1/qualitygate_types.go
@@ -47,7 +47,7 @@ type QualityGateParameters struct {
 // QualityGateObservation are the observable fields of a QualityGate.
 type QualityGateObservation struct {
 	// Actions represents the actions that can be performed on the Quality Gate.
-	Actions QualityGatesActions `json:"actions,omitempty"`
+	Actions QualityGatesActions `json:"actions,omitzero"`
 	// Defines the Clean as You Code status of the Quality Gate.
 	CaycStatus string `json:"caycStatus"`
 	// Conditions represents the list of conditions associated with the Quality Gate.
@@ -75,7 +75,7 @@ type QualityGateStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
 
 	// AtProvider represents the observed state of the Quality Gate.
-	AtProvider QualityGateObservation `json:"atProvider,omitempty"`
+	AtProvider QualityGateObservation `json:"atProvider,omitzero"`
 }
 
 // QualityGatesActions represents the actions that can be performed on a Quality Gate.
@@ -150,10 +150,10 @@ type QualityGateConditionObservation struct {
 // +kubebuilder:resource:scope=Namespaced,categories={crossplane,managed,sonarqube}
 type QualityGate struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	Spec   QualityGateSpec   `json:"spec"`
-	Status QualityGateStatus `json:"status,omitempty"`
+	Status QualityGateStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -161,7 +161,7 @@ type QualityGate struct {
 // QualityGateList contains a list of QualityGate.
 type QualityGateList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []QualityGate `json:"items"`
 }

--- a/apis/instance/v1alpha1/qualitygate_types.go
+++ b/apis/instance/v1alpha1/qualitygate_types.go
@@ -65,6 +65,7 @@ type QualityGateObservation struct {
 // A QualityGateSpec defines the desired state of a QualityGate.
 type QualityGateSpec struct {
 	xpv2.ManagedResourceSpec `json:",inline"`
+
 	// ForProvider represents the desired state of the Quality Gate.
 	ForProvider QualityGateParameters `json:"forProvider"`
 }
@@ -72,6 +73,7 @@ type QualityGateSpec struct {
 // A QualityGateStatus represents the observed state of a QualityGate.
 type QualityGateStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
+
 	// AtProvider represents the observed state of the Quality Gate.
 	AtProvider QualityGateObservation `json:"atProvider,omitempty"`
 }
@@ -156,16 +158,17 @@ type QualityGate struct {
 
 // +kubebuilder:object:root=true
 
-// QualityGateList contains a list of QualityGate
+// QualityGateList contains a list of QualityGate.
 type QualityGateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []QualityGate `json:"items"`
+
+	Items []QualityGate `json:"items"`
 }
 
 // QualityGate type metadata.
 var (
-	QualityGateKind             = reflect.TypeOf(QualityGate{}).Name()
+	QualityGateKind             = reflect.TypeFor[QualityGate]().Name()
 	QualityGateGroupKind        = schema.GroupKind{Group: Group, Kind: QualityGateKind}.String()
 	QualityGateKindAPIVersion   = QualityGateKind + "." + SchemeGroupVersion.String()
 	QualityGateGroupVersionKind = SchemeGroupVersion.WithKind(QualityGateKind)

--- a/apis/sonarqube.go
+++ b/apis/sonarqube.go
@@ -32,10 +32,10 @@ func init() {
 	)
 }
 
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
+// AddToSchemes may be used to add all resources defined in the project to a Scheme.
 var AddToSchemes runtime.SchemeBuilder
 
-// AddToScheme adds all Resources to the Scheme
+// AddToScheme adds all Resources to the Scheme.
 func AddToScheme(s *runtime.Scheme) error {
 	return AddToSchemes.AddToScheme(s)
 }

--- a/apis/v1alpha1/register.go
+++ b/apis/v1alpha1/register.go
@@ -14,42 +14,42 @@ const (
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
+	// SchemeGroupVersion is group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 )
 
 // ProviderConfig type metadata.
 var (
-	ProviderConfigKind             = reflect.TypeOf(ProviderConfig{}).Name()
+	ProviderConfigKind             = reflect.TypeFor[ProviderConfig]().Name()
 	ProviderConfigGroupKind        = schema.GroupKind{Group: Group, Kind: ProviderConfigKind}.String()
 	ProviderConfigGroupVersionKind = SchemeGroupVersion.WithKind(ProviderConfigKind)
 )
 
 // ProviderConfigUsage type metadata.
 var (
-	ProviderConfigUsageKind             = reflect.TypeOf(ProviderConfigUsage{}).Name()
+	ProviderConfigUsageKind             = reflect.TypeFor[ProviderConfigUsage]().Name()
 	ProviderConfigUsageGroupVersionKind = SchemeGroupVersion.WithKind(ProviderConfigUsageKind)
 
-	ProviderConfigUsageListKind             = reflect.TypeOf(ProviderConfigUsageList{}).Name()
+	ProviderConfigUsageListKind             = reflect.TypeFor[ProviderConfigUsageList]().Name()
 	ProviderConfigUsageListGroupVersionKind = SchemeGroupVersion.WithKind(ProviderConfigUsageListKind)
 )
 
-// ClusterProviderConfig type metadata
+// ClusterProviderConfig type metadata.
 var (
-	ClusterProviderConfigKind             = reflect.TypeOf(ClusterProviderConfig{}).Name()
+	ClusterProviderConfigKind             = reflect.TypeFor[ClusterProviderConfig]().Name()
 	ClusterProviderConfigGroupKind        = schema.GroupKind{Group: Group, Kind: ClusterProviderConfigKind}.String()
 	ClusterProviderConfigGroupVersionKind = SchemeGroupVersion.WithKind(ClusterProviderConfigKind)
 )
 
 // ClusterProviderConfigUsage type metadata.
 var (
-	ClusterProviderConfigUsageKind             = reflect.TypeOf(ClusterProviderConfigUsage{}).Name()
+	ClusterProviderConfigUsageKind             = reflect.TypeFor[ClusterProviderConfigUsage]().Name()
 	ClusterProviderConfigUsageGroupVersionKind = SchemeGroupVersion.WithKind(ClusterProviderConfigUsageKind)
 
-	ClusterProviderConfigUsageListKind             = reflect.TypeOf(ClusterProviderConfigUsageList{}).Name()
+	ClusterProviderConfigUsageListKind             = reflect.TypeFor[ClusterProviderConfigUsageList]().Name()
 	ClusterProviderConfigUsageListGroupVersionKind = SchemeGroupVersion.WithKind(ClusterProviderConfigUsageListKind)
 )
 

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -13,17 +13,17 @@ type ProviderConfigStatus struct {
 
 // ProviderCredentials required to authenticate.
 type ProviderCredentials struct {
+	xpv1.CommonCredentialSelectors `json:",inline"`
+
 	// Source of the provider credentials.
 	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
-
-	xpv1.CommonCredentialSelectors `json:",inline"`
 }
 
 type ProviderConfigSpec struct {
 	// BaseURL of the SonarQube instance.
 	// +kubebuilder:validation:Required
-	BaseURL string `json:"baseURL"`
+	BaseURL string `json:"baseUrl"`
 
 	// InsecureSkipVerify indicates whether to skip TLS certificate verification.
 	InsecureSkipVerify *bool `json:"insecureSkipVerify,omitempty"`
@@ -43,42 +43,42 @@ type ProviderConfigSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,sonarqube}
-// A ProviderConfig configures a Helm 'provider', i.e. a connection to a particular.
+
+// ProviderConfig configures a SonarQube provider.
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	Spec   ProviderConfigSpec   `json:"spec"`
-	Status ProviderConfigStatus `json:"status,omitempty"`
+	Status ProviderConfigStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
 
-// ProviderConfigList contains a list of Provider.
+// ProviderConfigList contains a list of ProviderConfig.
 type ProviderConfigList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ProviderConfig `json:"items"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
 // +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,sonarqube}
-// A ProviderConfigUsage indicates that a resource is using a ProviderConfig.
+
+// ProviderConfigUsage indicates that a resource is using a ProviderConfig.
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	xpv2.TypedProviderConfigUsage `json:",inline"`
 }
@@ -88,48 +88,48 @@ type ProviderConfigUsage struct {
 // ProviderConfigUsageList contains a list of ProviderConfigUsage.
 type ProviderConfigUsageList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ProviderConfigUsage `json:"items"`
 }
 
 // +kubebuilder:object:root=true
-
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,sonarqube}
-// A ClusterProviderConfig configures a SonarQube provider.
+
+// ClusterProviderConfig configures a SonarQube provider.
 type ClusterProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	Spec   ProviderConfigSpec   `json:"spec"`
-	Status ProviderConfigStatus `json:"status,omitempty"`
+	Status ProviderConfigStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
 
-// ClusterProviderConfigList contains a list of ProviderConfig.
+// ClusterProviderConfigList contains a list of ClusterProviderConfig.
 type ClusterProviderConfigList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ClusterProviderConfig `json:"items"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,sonarqube}
-// A ClusterProviderConfigUsage indicates that a resource is using a ClusterProviderConfig.
+
+// ClusterProviderConfigUsage indicates that a resource is using a ClusterProviderConfig.
 type ClusterProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	xpv2.TypedProviderConfigUsage `json:",inline"`
 }
@@ -139,7 +139,7 @@ type ClusterProviderConfigUsage struct {
 // ClusterProviderConfigUsageList contains a list of ClusterProviderConfigUsage.
 type ClusterProviderConfigUsageList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ClusterProviderConfigUsage `json:"items"`
 }

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -48,7 +48,7 @@ type ProviderConfigSpec struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,sonarqube}
-// A ProviderConfig configures a Helm 'provider', i.e. a connection to a particular
+// A ProviderConfig configures a Helm 'provider', i.e. a connection to a particular.
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -59,11 +59,12 @@ type ProviderConfig struct {
 
 // +kubebuilder:object:root=true
 
-// ProviderConfigList contains a list of Provider
+// ProviderConfigList contains a list of Provider.
 type ProviderConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ProviderConfig `json:"items"`
+
+	Items []ProviderConfig `json:"items"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,11 +85,12 @@ type ProviderConfigUsage struct {
 
 // +kubebuilder:object:root=true
 
-// ProviderConfigUsageList contains a list of ProviderConfigUsage
+// ProviderConfigUsageList contains a list of ProviderConfigUsage.
 type ProviderConfigUsageList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ProviderConfigUsage `json:"items"`
+
+	Items []ProviderConfigUsage `json:"items"`
 }
 
 // +kubebuilder:object:root=true
@@ -112,7 +114,8 @@ type ClusterProviderConfig struct {
 type ClusterProviderConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ClusterProviderConfig `json:"items"`
+
+	Items []ClusterProviderConfig `json:"items"`
 }
 
 // +kubebuilder:object:root=true
@@ -133,9 +136,10 @@ type ClusterProviderConfigUsage struct {
 
 // +kubebuilder:object:root=true
 
-// ClusterProviderConfigUsageList contains a list of ClusterProviderConfigUsage
+// ClusterProviderConfigUsageList contains a list of ClusterProviderConfigUsage.
 type ClusterProviderConfigUsageList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ClusterProviderConfigUsage `json:"items"`
+
+	Items []ClusterProviderConfigUsage `json:"items"`
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/crossplane/provider-sonarqube/internal/version"
 )
 
+//nolint:funlen,mnd,nlreturn,varnamelen // Default crossplane template main function, which is expected to be long and have many variables
 func main() {
 	var (
 		app            = kingpin.New(filepath.Base(os.Args[0]), "SonarQube support for Crossplane.").DefaultEnvars()

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -68,6 +67,7 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	zl := zap.New(zap.UseDevMode(*debug))
+
 	log := logging.NewLogrLogger(zl.WithName("provider-sonarqube"))
 	if *debug {
 		// The controller-runtime is *very* verbose even at info level, so we only
@@ -100,8 +100,14 @@ func main() {
 		LeaderElection:             *leaderElection,
 		LeaderElectionID:           "crossplane-leader-election-provider-sonarqube",
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),
-		RenewDeadline:              func() *time.Duration { d := 50 * time.Second; return &d }(),
+		LeaseDuration: func() *time.Duration {
+			d := 60 * time.Second
+			return &d
+		}(),
+		RenewDeadline: func() *time.Duration {
+			d := 50 * time.Second
+			return &d
+		}(),
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 
@@ -143,7 +149,7 @@ func main() {
 		clo := controller.ChangeLogOptions{
 			ChangeLogger: managed.NewGRPCChangeLogger(
 				changelogsv1alpha1.NewChangeLogServiceClient(conn),
-				managed.WithProviderVersion(fmt.Sprintf("provider-sonarqube:%s", version.Version))),
+				managed.WithProviderVersion("provider-sonarqube:"+version.Version)),
 		}
 		o.ChangeLogOptions = &clo
 	}

--- a/examples/providerconfig.yaml
+++ b/examples/providerconfig.yaml
@@ -28,7 +28,7 @@ metadata:
   name: example
   namespace: default
 spec:
-  baseURL: http://sonarqube.example.com/api
+  baseUrl: http://sonarqube.example.com/api
   token:
     source: Secret
     secretRef:
@@ -41,7 +41,7 @@ kind: ClusterProviderConfig
 metadata:
   name: example
 spec:
-  baseURL: http://sonarqube.example.com/api
+  baseUrl: http://sonarqube.example.com/api
   username:
     source: Secret
     secretRef:

--- a/internal/clients/common/auth.go
+++ b/internal/clients/common/auth.go
@@ -17,7 +17,7 @@ limitations under the License.
 package common
 
 const (
-	// BasicAuth is SonarQube's BasicAuth method of authentification that needs a username and a password
+	// BasicAuth is SonarQube's BasicAuth method of authentification that needs a username and a password.
 	BasicAuth AuthType = "BasicAuth"
 
 	// PersonalAccessToken is SonarQube's PersonalAccessToken method of authentification.

--- a/internal/clients/common/auth_test.go
+++ b/internal/clients/common/auth_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestAuthTypeConstants(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		authType AuthType
 		want     string
@@ -37,6 +39,8 @@ func TestAuthTypeConstants(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			if string(tc.authType) != tc.want {
 				t.Errorf("AuthType = %v, want %v", tc.authType, tc.want)
 			}

--- a/internal/clients/common/kubernetes.go
+++ b/internal/clients/common/kubernetes.go
@@ -43,6 +43,7 @@ func GetTokenValueFromSecret(ctx context.Context, client client.Client, m resour
 	}
 
 	secret := &corev1.Secret{}
+
 	err := client.Get(ctx, types.NamespacedName{Name: selector.Name, Namespace: selector.Namespace}, secret)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrSecretNotFound)
@@ -59,16 +60,16 @@ func GetTokenValueFromSecret(ctx context.Context, client client.Client, m resour
 }
 
 // GetTokenValueFromLocalSecret retrieves the token value from a local secret in the same namespace as the managed resource.
-func GetTokenValueFromLocalSecret(ctx context.Context, client client.Client, m resource.Managed, l *xpv1.LocalSecretKeySelector) (*string, error) {
-	if l == nil {
+func GetTokenValueFromLocalSecret(ctx context.Context, client client.Client, managedResource resource.Managed, localSelector *xpv1.LocalSecretKeySelector) (*string, error) {
+	if localSelector == nil {
 		return nil, errors.Errorf(ErrSecretSelectorNil)
 	}
 
-	return GetTokenValueFromSecret(ctx, client, m, &xpv1.SecretKeySelector{
-		Key: l.Key,
+	return GetTokenValueFromSecret(ctx, client, managedResource, &xpv1.SecretKeySelector{
+		Key: localSelector.Key,
 		SecretReference: xpv1.SecretReference{
-			Name:      l.Name,
-			Namespace: m.GetNamespace(),
+			Name:      localSelector.Name,
+			Namespace: managedResource.GetNamespace(),
 		},
 	})
 }

--- a/internal/clients/common/kubernetes.go
+++ b/internal/clients/common/kubernetes.go
@@ -43,7 +43,8 @@ func GetTokenValueFromSecret(ctx context.Context, client client.Client, m resour
 	}
 
 	secret := &corev1.Secret{}
-	if err := client.Get(ctx, types.NamespacedName{Name: selector.Name, Namespace: selector.Namespace}, secret); err != nil {
+	err := client.Get(ctx, types.NamespacedName{Name: selector.Name, Namespace: selector.Namespace}, secret)
+	if err != nil {
 		return nil, errors.Wrap(err, ErrSecretNotFound)
 	}
 
@@ -53,6 +54,7 @@ func GetTokenValueFromSecret(ctx context.Context, client client.Client, m resour
 	}
 
 	data := string(value)
+
 	return &data, nil
 }
 

--- a/internal/clients/common/kubernetes_test.go
+++ b/internal/clients/common/kubernetes_test.go
@@ -54,6 +54,7 @@ func TestGetTokenValueFromSecret(t *testing.T) {
 		m        resource.Managed
 		selector *xpv1.SecretKeySelector
 	}
+
 	tests := map[string]struct {
 		args        args
 		want        *string
@@ -144,22 +145,30 @@ func TestGetTokenValueFromSecret(t *testing.T) {
 			got, err := GetTokenValueFromSecret(tc.args.ctx, tc.args.client, tc.args.m, tc.args.selector)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("GetTokenValueFromSecret() error = %v, wantErr %v", err, tc.wantErr)
+
 				return
 			}
+
 			if tc.wantErr && tc.errContains != "" {
 				if err == nil || !containsString(err.Error(), tc.errContains) {
 					t.Errorf("GetTokenValueFromSecret() error = %v, should contain %v", err, tc.errContains)
 				}
+
 				return
 			}
+
 			if tc.want == nil && got != nil {
 				t.Errorf("GetTokenValueFromSecret() = %v, want nil", *got)
+
 				return
 			}
+
 			if tc.want != nil && got == nil {
 				t.Errorf("GetTokenValueFromSecret() = nil, want %v", *tc.want)
+
 				return
 			}
+
 			if tc.want != nil && got != nil && *got != *tc.want {
 				t.Errorf("GetTokenValueFromSecret() = %v, want %v", *got, *tc.want)
 			}
@@ -174,6 +183,7 @@ func TestGetTokenValueFromLocalSecret(t *testing.T) {
 		m      resource.Managed
 		l      *xpv1.LocalSecretKeySelector
 	}
+
 	tests := map[string]struct {
 		args        args
 		want        *string
@@ -245,22 +255,30 @@ func TestGetTokenValueFromLocalSecret(t *testing.T) {
 			got, err := GetTokenValueFromLocalSecret(tc.args.ctx, tc.args.client, tc.args.m, tc.args.l)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("GetTokenValueFromLocalSecret() error = %v, wantErr %v", err, tc.wantErr)
+
 				return
 			}
+
 			if tc.wantErr && tc.errContains != "" {
 				if err == nil || !containsString(err.Error(), tc.errContains) {
 					t.Errorf("GetTokenValueFromLocalSecret() error = %v, should contain %v", err, tc.errContains)
 				}
+
 				return
 			}
+
 			if tc.want == nil && got != nil {
 				t.Errorf("GetTokenValueFromLocalSecret() = %v, want nil", *got)
+
 				return
 			}
+
 			if tc.want != nil && got == nil {
 				t.Errorf("GetTokenValueFromLocalSecret() = nil, want %v", *tc.want)
+
 				return
 			}
+
 			if tc.want != nil && got != nil && *got != *tc.want {
 				t.Errorf("GetTokenValueFromLocalSecret() = %v, want %v", *got, *tc.want)
 			}
@@ -285,5 +303,6 @@ func findSubstring(s, substr string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/clients/common/kubernetes_test.go
+++ b/internal/clients/common/kubernetes_test.go
@@ -48,6 +48,8 @@ func newFakeClient(objs ...runtime.Object) client.Client {
 }
 
 func TestGetTokenValueFromSecret(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx      context.Context
 		client   client.Client
@@ -142,6 +144,8 @@ func TestGetTokenValueFromSecret(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := GetTokenValueFromSecret(tc.args.ctx, tc.args.client, tc.args.m, tc.args.selector)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("GetTokenValueFromSecret() error = %v, wantErr %v", err, tc.wantErr)
@@ -177,6 +181,8 @@ func TestGetTokenValueFromSecret(t *testing.T) {
 }
 
 func TestGetTokenValueFromLocalSecret(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx    context.Context
 		client client.Client
@@ -252,6 +258,8 @@ func TestGetTokenValueFromLocalSecret(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := GetTokenValueFromLocalSecret(tc.args.ctx, tc.args.client, tc.args.m, tc.args.l)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("GetTokenValueFromLocalSecret() error = %v, wantErr %v", err, tc.wantErr)

--- a/internal/clients/common/sonar.go
+++ b/internal/clients/common/sonar.go
@@ -132,6 +132,7 @@ func UseProviderConfig(ctx context.Context, kubeClient client.Client, managedRes
 	switch providerConfigRef.Kind {
 	case "ClusterProviderConfig":
 		cpc := &v1alpha1.ClusterProviderConfig{}
+
 		err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name}, cpc)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ClusterProviderConfig")
@@ -139,20 +140,23 @@ func UseProviderConfig(ctx context.Context, kubeClient client.Client, managedRes
 
 		return buildConfigFromSpec(ctx, kubeClient, managedResource, cpc.Spec)
 	default: // "ProviderConfig" or empty (default)
-		pc := &v1alpha1.ProviderConfig{}
-		err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name, Namespace: managedResource.GetNamespace()}, pc)
+		providerConfig := &v1alpha1.ProviderConfig{}
+
+		err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name, Namespace: managedResource.GetNamespace()}, providerConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ProviderConfig")
 		}
 
-		return buildConfigFromSpec(ctx, kubeClient, managedResource, pc.Spec)
+		return buildConfigFromSpec(ctx, kubeClient, managedResource, providerConfig.Spec)
 	}
 }
 
 // buildConfigFromSpec builds a Config from the given ProviderConfigSpec.
 func buildConfigFromSpec(ctx context.Context, kubeClient client.Client, managedResource resource.ModernManaged, spec v1alpha1.ProviderConfigSpec) (*Config, error) {
 	t := resource.NewProviderConfigUsageTracker(kubeClient, &v1alpha1.ProviderConfigUsage{})
-	if err := t.Track(ctx, managedResource); err != nil {
+
+	err := t.Track(ctx, managedResource)
+	if err != nil {
 		return nil, errors.Wrap(err, "cannot track ProviderConfig usage")
 	}
 
@@ -202,38 +206,47 @@ func buildConfigFromSpec(ctx context.Context, kubeClient client.Client, managedR
 func determineAuthType(spec v1alpha1.ProviderConfigSpec) (AuthType, error) {
 	// Check if Token is provided for Personal Access Token authentication
 	if spec.Token != nil {
-		switch spec.Token.Source {
-		case xpv1.CredentialsSourceSecret:
-			if spec.Token.SecretRef == nil {
-				return "", errors.New("secretRef must be provided for token")
-			}
+		return validateTokenAuth(spec.Token)
+	}
 
-			return PersonalAccessToken, nil
-		default:
-			return "", errors.Errorf("credentials source %s for token is not currently supported", spec.Token.Source)
-		}
-	} else if spec.Username != nil && spec.Password != nil {
-		// Check if Username and Password are provided for Basic Authentication
-		switch spec.Username.Source {
-		case xpv1.CredentialsSourceSecret:
-			if spec.Username.SecretRef == nil {
-				return "", errors.New("secretRef must be provided for username")
-			}
-
-			switch spec.Password.Source {
-			case xpv1.CredentialsSourceSecret:
-				if spec.Password.SecretRef == nil {
-					return "", errors.New("secretRef must be provided for password")
-				}
-
-				return BasicAuth, nil
-			default:
-				return "", errors.Errorf("credentials source %s for password is not currently supported", spec.Password.Source)
-			}
-		default:
-			return "", errors.Errorf("credentials source %s for username is not currently supported", spec.Username.Source)
-		}
+	// Check if Username and Password are provided for Basic Authentication
+	if spec.Username != nil && spec.Password != nil {
+		return validateBasicAuth(spec.Username, spec.Password)
 	}
 
 	return "", errors.New("no valid authentication method found in ProviderConfigSpec")
+}
+
+// validateTokenAuth validates token-based authentication configuration.
+func validateTokenAuth(token *v1alpha1.ProviderCredentials) (AuthType, error) {
+	if token.Source != xpv1.CredentialsSourceSecret {
+		return "", errors.Errorf("credentials source %s for token is not currently supported", token.Source)
+	}
+
+	if token.SecretRef == nil {
+		return "", errors.New("secretRef must be provided for token")
+	}
+
+	return PersonalAccessToken, nil
+}
+
+// validateBasicAuth validates basic authentication configuration.
+func validateBasicAuth(username, password *v1alpha1.ProviderCredentials) (AuthType, error) {
+	if username.Source != xpv1.CredentialsSourceSecret {
+		return "", errors.Errorf("credentials source %s for username is not currently supported", username.Source)
+	}
+
+	if username.SecretRef == nil {
+		return "", errors.New("secretRef must be provided for username")
+	}
+
+	if password.Source != xpv1.CredentialsSourceSecret {
+		return "", errors.Errorf("credentials source %s for password is not currently supported", password.Source)
+	}
+
+	if password.SecretRef == nil {
+		return "", errors.New("secretRef must be provided for password")
+	}
+
+	return BasicAuth, nil
 }

--- a/internal/clients/common/sonar.go
+++ b/internal/clients/common/sonar.go
@@ -31,13 +31,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// BasicAuthArgs is the expected struct that can be passed in the Config.Token field to add support for BasicAuth AuthMethod
+// BasicAuthArgs is the expected struct that can be passed in the Config.Token field to add support for BasicAuth AuthMethod.
 type BasicAuthArgs struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
 
-// Config provides SonarQube configurations for the SonarQube client
+// Config provides SonarQube configurations for the SonarQube client.
 type Config struct {
 	// AuthType is the SonarQube authentication type to use (e.g., BasicAuth, PersonalAccessToken)
 	AuthType AuthType
@@ -70,6 +70,7 @@ func NewClient(clientConfig Config) *sonar.Client {
 		if err != nil {
 			panic(err)
 		}
+
 		client = sonarClient
 	case PersonalAccessToken:
 		// Create SonarQube client with Personal Access Token
@@ -81,6 +82,7 @@ func NewClient(clientConfig Config) *sonar.Client {
 		if err != nil {
 			panic(err)
 		}
+
 		client = sonarClient
 	default:
 		panic(errors.New("unsupported authentication type"))
@@ -96,16 +98,18 @@ func NewClient(clientConfig Config) *sonar.Client {
 				MinVersion: tls.VersionTLS12,
 			}
 		}
+
 		transport.TLSClientConfig.InsecureSkipVerify = true
 		httpClient.Transport = transport
 	}
+
 	client.SetHTTPClient(httpClient)
 
 	return client
 }
 
 // GetConfig constructs a Config that can be used to authenticate to SonarQube's
-// API by the SonarQube Go client
+// API by the SonarQube Go client.
 func GetConfig(ctx context.Context, kubeClient client.Client, managedResource resource.Managed) (*Config, error) {
 	switch managedResourceCast := managedResource.(type) {
 	case resource.ModernManaged:
@@ -121,27 +125,31 @@ func GetConfig(ctx context.Context, kubeClient client.Client, managedResource re
 }
 
 // UseProviderConfig uses the given ProviderConfig reference to construct a Config
-// that can be used to authenticate to SonarQube's API by the SonarQube Go client
+// that can be used to authenticate to SonarQube's API by the SonarQube Go client.
 func UseProviderConfig(ctx context.Context, kubeClient client.Client, managedResource resource.ModernManaged) (*Config, error) {
 	providerConfigRef := managedResource.GetProviderConfigReference()
 
 	switch providerConfigRef.Kind {
 	case "ClusterProviderConfig":
 		cpc := &v1alpha1.ClusterProviderConfig{}
-		if err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name}, cpc); err != nil {
+		err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name}, cpc)
+		if err != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ClusterProviderConfig")
 		}
+
 		return buildConfigFromSpec(ctx, kubeClient, managedResource, cpc.Spec)
 	default: // "ProviderConfig" or empty (default)
 		pc := &v1alpha1.ProviderConfig{}
-		if err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name, Namespace: managedResource.GetNamespace()}, pc); err != nil {
+		err := kubeClient.Get(ctx, types.NamespacedName{Name: providerConfigRef.Name, Namespace: managedResource.GetNamespace()}, pc)
+		if err != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ProviderConfig")
 		}
+
 		return buildConfigFromSpec(ctx, kubeClient, managedResource, pc.Spec)
 	}
 }
 
-// buildConfigFromSpec builds a Config from the given ProviderConfigSpec
+// buildConfigFromSpec builds a Config from the given ProviderConfigSpec.
 func buildConfigFromSpec(ctx context.Context, kubeClient client.Client, managedResource resource.ModernManaged, spec v1alpha1.ProviderConfigSpec) (*Config, error) {
 	t := resource.NewProviderConfigUsageTracker(kubeClient, &v1alpha1.ProviderConfigUsage{})
 	if err := t.Track(ctx, managedResource); err != nil {
@@ -157,6 +165,7 @@ func buildConfigFromSpec(ctx context.Context, kubeClient client.Client, managedR
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot determine authentication type from ProviderConfigSpec")
 	}
+
 	config.AuthType = authType
 
 	switch authType {
@@ -165,16 +174,19 @@ func buildConfigFromSpec(ctx context.Context, kubeClient client.Client, managedR
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get token from secret")
 		}
+
 		config.Token = *token
 	case BasicAuth:
 		username, err := GetTokenValueFromSecret(ctx, kubeClient, managedResource, spec.Username.SecretRef)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get username from secret")
 		}
+
 		password, err := GetTokenValueFromSecret(ctx, kubeClient, managedResource, spec.Password.SecretRef)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get password from secret")
 		}
+
 		config.BasicAuth = &BasicAuthArgs{
 			Username: *username,
 			Password: *password,
@@ -186,7 +198,7 @@ func buildConfigFromSpec(ctx context.Context, kubeClient client.Client, managedR
 
 // determineAuthType determines the AuthType based on the provided ProviderConfigSpec
 // It populates the AuthType and BasicAuth fields in the Config struct accordingly
-// It returns an error if no valid authentication method is found
+// It returns an error if no valid authentication method is found.
 func determineAuthType(spec v1alpha1.ProviderConfigSpec) (AuthType, error) {
 	// Check if Token is provided for Personal Access Token authentication
 	if spec.Token != nil {
@@ -195,6 +207,7 @@ func determineAuthType(spec v1alpha1.ProviderConfigSpec) (AuthType, error) {
 			if spec.Token.SecretRef == nil {
 				return "", errors.New("secretRef must be provided for token")
 			}
+
 			return PersonalAccessToken, nil
 		default:
 			return "", errors.Errorf("credentials source %s for token is not currently supported", spec.Token.Source)
@@ -206,11 +219,13 @@ func determineAuthType(spec v1alpha1.ProviderConfigSpec) (AuthType, error) {
 			if spec.Username.SecretRef == nil {
 				return "", errors.New("secretRef must be provided for username")
 			}
+
 			switch spec.Password.Source {
 			case xpv1.CredentialsSourceSecret:
 				if spec.Password.SecretRef == nil {
 					return "", errors.New("secretRef must be provided for password")
 				}
+
 				return BasicAuth, nil
 			default:
 				return "", errors.Errorf("credentials source %s for password is not currently supported", spec.Password.Source)

--- a/internal/clients/instance/qualitygate.go
+++ b/internal/clients/instance/qualitygate.go
@@ -29,6 +29,8 @@ import (
 // It handles all the operations related to Quality Gates in SonarQube, such as creating, updating, deleting, and retrieving Quality Gates and their conditions.
 // It also handles users / groups / projects association with Quality Gates.
 // It also interacts with Quality Gate Conditions.
+//
+//nolint:interfacebloat // This interface wraps the SonarQube Quality Gates API which has 21 methods
 type QualityGatesClient interface {
 	AddGroup(opt *sonar.QualitygatesAddGroupOption) (resp *http.Response, err error)
 	AddUser(opt *sonar.QualitygatesAddUserOption) (resp *http.Response, err error)
@@ -159,9 +161,9 @@ func LateInitializeQualityGate(spec *v1alpha1.QualityGateParameters, observation
 	observationIdSet := buildObservationIdSet(observation.Conditions)
 
 	// Late-initialize or update condition IDs by matching on metric, error, and op
-	for i := range spec.Conditions {
+	for idx := range spec.Conditions {
 		// Check if the spec has an ID that still exists in observations
-		hasValidId := spec.Conditions[i].Id != nil && observationIdSet[*spec.Conditions[i].Id]
+		hasValidId := spec.Conditions[idx].Id != nil && observationIdSet[*spec.Conditions[idx].Id]
 
 		if hasValidId {
 			// Already has a valid ID that exists in observations, skip
@@ -169,8 +171,8 @@ func LateInitializeQualityGate(spec *v1alpha1.QualityGateParameters, observation
 		}
 
 		// Either no ID or stale ID - find matching observation by metric, error, and op
-		if matchingId := findMatchingObservationId(spec.Conditions[i], observation.Conditions); matchingId != nil {
-			spec.Conditions[i].Id = matchingId
+		if matchingId := findMatchingObservationId(spec.Conditions[idx], observation.Conditions); matchingId != nil {
+			spec.Conditions[idx].Id = matchingId
 		}
 	}
 }

--- a/internal/clients/instance/qualitygate.go
+++ b/internal/clients/instance/qualitygate.go
@@ -56,10 +56,11 @@ type QualityGatesClient interface {
 // NewQualityGatesClient creates a new QualityGatesClient with the provided SonarQube client configuration.
 func NewQualityGatesClient(clientConfig common.Config) QualityGatesClient {
 	newClient := common.NewClient(clientConfig)
+
 	return newClient.Qualitygates
 }
 
-// GenerateQualityGateCreateOptions generates SonarQube QualitygatesCreateOption from QualityGateParameters
+// GenerateQualityGateCreateOptions generates SonarQube QualitygatesCreateOption from QualityGateParameters.
 func GenerateQualityGateCreateOptions(spec v1alpha1.QualityGateParameters) *sonar.QualitygatesCreateOption {
 	return &sonar.QualitygatesCreateOption{
 		Name: spec.Name,
@@ -67,7 +68,7 @@ func GenerateQualityGateCreateOptions(spec v1alpha1.QualityGateParameters) *sona
 }
 
 // GenerateQualityGateObservation generates QualityGateObservation from SonarQube QualityGate
-// observation should not be nil, else it will panic
+// observation should not be nil, else it will panic.
 func GenerateQualityGateObservation(observation *sonar.QualitygatesShow) v1alpha1.QualityGateObservation {
 	return v1alpha1.QualityGateObservation{
 		Actions:           GenerateQualityGateActionsObservation(&observation.Actions),
@@ -81,7 +82,7 @@ func GenerateQualityGateObservation(observation *sonar.QualitygatesShow) v1alpha
 }
 
 // GenerateQualityGateActionsObservation generates QualityGatesActions from SonarQube QualityGateActions
-// actions should not be nil, else it will panic
+// actions should not be nil, else it will panic.
 func GenerateQualityGateActionsObservation(actions *sonar.QualityGateActions) v1alpha1.QualityGatesActions {
 	return v1alpha1.QualityGatesActions{
 		AssociateProjects:     actions.AssociateProjects,
@@ -95,11 +96,12 @@ func GenerateQualityGateActionsObservation(actions *sonar.QualityGateActions) v1
 	}
 }
 
-// IsQualityGateUpToDate checks if the Quality Gate spec is up to date with the observed state
+// IsQualityGateUpToDate checks if the Quality Gate spec is up to date with the observed state.
 func IsQualityGateUpToDate(spec *v1alpha1.QualityGateParameters, observation *v1alpha1.QualityGateObservation, associations map[string]QualityGateConditionAssociation) bool {
 	if spec == nil {
 		return true
 	}
+
 	if observation == nil {
 		return false
 	}
@@ -119,17 +121,18 @@ func IsQualityGateUpToDate(spec *v1alpha1.QualityGateParameters, observation *v1
 	return true
 }
 
-// buildObservationIdSet creates a map of all observation condition IDs for quick lookup
+// buildObservationIdSet creates a map of all observation condition IDs for quick lookup.
 func buildObservationIdSet(conditions []v1alpha1.QualityGateConditionObservation) map[string]bool {
 	idSet := make(map[string]bool)
 	for i := range conditions {
 		idSet[conditions[i].ID] = true
 	}
+
 	return idSet
 }
 
 // findMatchingObservationId searches for an observation condition that matches the spec condition
-// by metric, error, and op, and returns its ID
+// by metric, error, and op, and returns its ID.
 func findMatchingObservationId(specCondition v1alpha1.QualityGateConditionParameters, observations []v1alpha1.QualityGateConditionObservation) *string {
 	for i := range observations {
 		if specCondition.Metric == observations[i].Metric &&
@@ -138,12 +141,13 @@ func findMatchingObservationId(specCondition v1alpha1.QualityGateConditionParame
 			return &observations[i].ID
 		}
 	}
+
 	return nil
 }
 
 // LateInitializeQualityGate fills the spec with the observed state if the spec fields are nil
 // It also late-initializes condition IDs by matching conditions by their metric, error, and op fields
-// If a condition has a stale ID (doesn't exist in observations), it will be updated to the correct ID
+// If a condition has a stale ID (doesn't exist in observations), it will be updated to the correct ID.
 func LateInitializeQualityGate(spec *v1alpha1.QualityGateParameters, observation *v1alpha1.QualityGateObservation) {
 	if spec == nil || observation == nil {
 		return
@@ -172,7 +176,7 @@ func LateInitializeQualityGate(spec *v1alpha1.QualityGateParameters, observation
 }
 
 // WereQualityGateConditionsLateInitialized checks if any conditions had their IDs late-initialized
-// by comparing the before and after states
+// by comparing the before and after states.
 func WereQualityGateConditionsLateInitialized(before, after []v1alpha1.QualityGateConditionParameters) bool {
 	if len(before) != len(after) {
 		return true

--- a/internal/clients/instance/qualitygate_condition.go
+++ b/internal/clients/instance/qualitygate_condition.go
@@ -145,27 +145,27 @@ func GenerateQualityGateConditionsAssociation(specs []v1alpha1.QualityGateCondit
 	}
 
 	// Create associations for specs with IDs
-	for i := range specs {
-		if specs[i].Id != nil {
-			if assoc, exists := associations[*specs[i].Id]; exists {
-				assoc.Spec = &specs[i]
-				assoc.UpToDate = IsQualityGateConditionUpToDate(&specs[i], assoc.Observation)
-				associations[*specs[i].Id] = assoc
+	for idx := range specs {
+		if specs[idx].Id != nil {
+			if assoc, exists := associations[*specs[idx].Id]; exists {
+				assoc.Spec = &specs[idx]
+				assoc.UpToDate = IsQualityGateConditionUpToDate(&specs[idx], assoc.Observation)
+				associations[*specs[idx].Id] = assoc
 			} else {
 				// Spec has an ID but no matching observation (stale ID reference)
-				associations[*specs[i].Id] = QualityGateConditionAssociation{
+				associations[*specs[idx].Id] = QualityGateConditionAssociation{
 					Observation: nil,
-					Spec:        &specs[i],
+					Spec:        &specs[idx],
 					UpToDate:    false,
 				}
 			}
 		} else {
 			// Spec without ID is a new condition that needs to be created
 			// Use a unique placeholder key based on metric to track it
-			key := "new:" + specs[i].Metric
+			key := "new:" + specs[idx].Metric
 			associations[key] = QualityGateConditionAssociation{
 				Observation: nil,
-				Spec:        &specs[i],
+				Spec:        &specs[idx],
 				UpToDate:    false,
 			}
 		}

--- a/internal/clients/instance/qualitygate_condition.go
+++ b/internal/clients/instance/qualitygate_condition.go
@@ -22,7 +22,7 @@ import (
 	"github.com/crossplane/provider-sonarqube/internal/helpers"
 )
 
-// GenerateQualityGateConditionObservation generates QualityGateConditionObservation from SonarQube QualityGateCondition
+// GenerateQualityGateConditionObservation generates QualityGateConditionObservation from SonarQube QualityGateCondition.
 func GenerateQualityGateConditionObservation(condition *sonar.QualityGateCondition) v1alpha1.QualityGateConditionObservation {
 	return v1alpha1.QualityGateConditionObservation{
 		Error:  condition.Error,
@@ -32,7 +32,7 @@ func GenerateQualityGateConditionObservation(condition *sonar.QualityGateConditi
 	}
 }
 
-// GenerateQualityGateConditionObservationFromCreate generates QualityGateConditionObservation from SonarQube QualityGateCondition
+// GenerateQualityGateConditionObservationFromCreate generates QualityGateConditionObservation from SonarQube QualityGateCondition.
 func GenerateQualityGateConditionObservationFromCreate(condition *sonar.QualitygatesCreateCondition) *v1alpha1.QualityGateConditionObservation {
 	return &v1alpha1.QualityGateConditionObservation{
 		Error:  condition.Error,
@@ -42,16 +42,17 @@ func GenerateQualityGateConditionObservationFromCreate(condition *sonar.Qualityg
 	}
 }
 
-// GenerateQualityGateConditionsObservation generates a slice of QualityGateConditionObservation from a slice of SonarQube QualityGateCondition
+// GenerateQualityGateConditionsObservation generates a slice of QualityGateConditionObservation from a slice of SonarQube QualityGateCondition.
 func GenerateQualityGateConditionsObservation(conditions []sonar.QualityGateCondition) []v1alpha1.QualityGateConditionObservation {
 	conditionObservations := make([]v1alpha1.QualityGateConditionObservation, len(conditions))
 	for i, condition := range conditions {
 		conditionObservations[i] = GenerateQualityGateConditionObservation(&condition)
 	}
+
 	return conditionObservations
 }
 
-// GenerateCreateQualityGateConditionOption generates SonarQube QualitygatesCreateConditionOption from QualityGateConditionParameters
+// GenerateCreateQualityGateConditionOption generates SonarQube QualitygatesCreateConditionOption from QualityGateConditionParameters.
 func GenerateCreateQualityGateConditionOption(gateName string, params v1alpha1.QualityGateConditionParameters) *sonar.QualitygatesCreateConditionOption {
 	option := sonar.QualitygatesCreateConditionOption{
 		GateName: gateName,
@@ -61,10 +62,11 @@ func GenerateCreateQualityGateConditionOption(gateName string, params v1alpha1.Q
 	if params.Op != nil {
 		option.Op = *params.Op
 	}
+
 	return &option
 }
 
-// GenerateUpdateQualityGateConditionOption generates SonarQube QualitygatesUpdateConditionOption from QualityGateConditionParameters
+// GenerateUpdateQualityGateConditionOption generates SonarQube QualitygatesUpdateConditionOption from QualityGateConditionParameters.
 func GenerateUpdateQualityGateConditionOption(id string, params v1alpha1.QualityGateConditionParameters) *sonar.QualitygatesUpdateConditionOption {
 	option := sonar.QualitygatesUpdateConditionOption{
 		ID:     id,
@@ -74,10 +76,11 @@ func GenerateUpdateQualityGateConditionOption(id string, params v1alpha1.Quality
 	if params.Op != nil {
 		option.Op = *params.Op
 	}
+
 	return &option
 }
 
-// GenerateDeleteQualityGateConditionOption generates SonarQube QualitygatesDeleteConditionOption from QualityGateConditionObservation
+// GenerateDeleteQualityGateConditionOption generates SonarQube QualitygatesDeleteConditionOption from QualityGateConditionObservation.
 func GenerateDeleteQualityGateConditionOption(id string) *sonar.QualitygatesDeleteConditionOption {
 	return &sonar.QualitygatesDeleteConditionOption{
 		ID: id,
@@ -97,11 +100,12 @@ func LateInitializeQualityGateCondition(params *v1alpha1.QualityGateConditionPar
 	helpers.AssignIfNil(&params.Op, observation.Op)
 }
 
-// IsQualityGateConditionUpToDate checks whether the observed QualityGateCondition is up to date with the desired QualityGateConditionParameters
+// IsQualityGateConditionUpToDate checks whether the observed QualityGateCondition is up to date with the desired QualityGateConditionParameters.
 func IsQualityGateConditionUpToDate(params *v1alpha1.QualityGateConditionParameters, observation *v1alpha1.QualityGateConditionObservation) bool {
 	if params == nil {
 		return true
 	}
+
 	if observation == nil {
 		return false
 	}
@@ -109,9 +113,11 @@ func IsQualityGateConditionUpToDate(params *v1alpha1.QualityGateConditionParamet
 	if params.Error != observation.Error {
 		return false
 	}
+
 	if params.Metric != observation.Metric {
 		return false
 	}
+
 	if !helpers.IsComparablePtrEqualComparable(params.Op, observation.Op) {
 		return false
 	}
@@ -119,14 +125,14 @@ func IsQualityGateConditionUpToDate(params *v1alpha1.QualityGateConditionParamet
 	return true
 }
 
-// QualityGateConditionAssociation associates a QualityGateConditionObservation with its corresponding QualityGateConditionParameters
+// QualityGateConditionAssociation associates a QualityGateConditionObservation with its corresponding QualityGateConditionParameters.
 type QualityGateConditionAssociation struct {
 	Observation *v1alpha1.QualityGateConditionObservation
 	Spec        *v1alpha1.QualityGateConditionParameters
 	UpToDate    bool
 }
 
-// GenerateQualityGateConditionsAssociation generates associations between QualityGateConditionParameters and QualityGateConditionObservation
+// GenerateQualityGateConditionsAssociation generates associations between QualityGateConditionParameters and QualityGateConditionObservation.
 func GenerateQualityGateConditionsAssociation(specs []v1alpha1.QualityGateConditionParameters, observations []v1alpha1.QualityGateConditionObservation) map[string]QualityGateConditionAssociation {
 	associations := make(map[string]QualityGateConditionAssociation)
 
@@ -168,19 +174,21 @@ func GenerateQualityGateConditionsAssociation(specs []v1alpha1.QualityGateCondit
 	return associations
 }
 
-// AreQualityGateConditionsUpToDate checks whether the observed QualityGateConditions are up to date with the desired QualityGateConditionParameters
+// AreQualityGateConditionsUpToDate checks whether the observed QualityGateConditions are up to date with the desired QualityGateConditionParameters.
 func AreQualityGateConditionsUpToDate(associations map[string]QualityGateConditionAssociation) bool {
 	for _, assoc := range associations {
 		if !assoc.UpToDate {
 			return false
 		}
 	}
+
 	return true
 }
 
-// FindNonExistingQualityGateConditions finds QualityGateConditionParameters that do not have a corresponding QualityGateConditionObservation
+// FindNonExistingQualityGateConditions finds QualityGateConditionParameters that do not have a corresponding QualityGateConditionObservation.
 func FindNonExistingQualityGateConditions(associations map[string]QualityGateConditionAssociation) []*v1alpha1.QualityGateConditionParameters {
 	var nonExisting []*v1alpha1.QualityGateConditionParameters
+
 	for _, assoc := range associations {
 		if assoc.Observation == nil && assoc.Spec != nil {
 			nonExisting = append(nonExisting, assoc.Spec)
@@ -190,25 +198,29 @@ func FindNonExistingQualityGateConditions(associations map[string]QualityGateCon
 	return nonExisting
 }
 
-// FindMissingQualityGateConditions finds QualityGateConditionObservations that do not have a corresponding QualityGateConditionParameters
+// FindMissingQualityGateConditions finds QualityGateConditionObservations that do not have a corresponding QualityGateConditionParameters.
 func FindMissingQualityGateConditions(associations map[string]QualityGateConditionAssociation) []*v1alpha1.QualityGateConditionObservation {
 	var missing []*v1alpha1.QualityGateConditionObservation
+
 	for _, assoc := range associations {
 		if assoc.Spec == nil && assoc.Observation != nil {
 			missing = append(missing, assoc.Observation)
 		}
 	}
+
 	return missing
 }
 
 // FindNotUpToDateQualityGateConditions finds QualityGateConditionParameters that are not up to date with their corresponding QualityGateConditionObservation
-// This ignores associations where either Spec or Observation is nil
+// This ignores associations where either Spec or Observation is nil.
 func FindNotUpToDateQualityGateConditions(associations map[string]QualityGateConditionAssociation) []QualityGateConditionAssociation {
 	var notUpToDate []QualityGateConditionAssociation
+
 	for _, assoc := range associations {
 		if !assoc.UpToDate && assoc.Spec != nil && assoc.Observation != nil {
 			notUpToDate = append(notUpToDate, assoc)
 		}
 	}
+
 	return notUpToDate
 }

--- a/internal/clients/instance/qualitygate_condition_test.go
+++ b/internal/clients/instance/qualitygate_condition_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestGenerateQualityGateConditionObservation(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		condition *sonar.QualityGateCondition
 		want      v1alpha1.QualityGateConditionObservation
@@ -67,6 +69,8 @@ func TestGenerateQualityGateConditionObservation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateConditionObservation(tc.condition)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateQualityGateConditionObservation() mismatch (-want +got):\n%s", diff)
@@ -76,6 +80,8 @@ func TestGenerateQualityGateConditionObservation(t *testing.T) {
 }
 
 func TestGenerateQualityGateConditionsObservation(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		conditions []sonar.QualityGateCondition
 		want       []v1alpha1.QualityGateConditionObservation
@@ -108,6 +114,8 @@ func TestGenerateQualityGateConditionsObservation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateConditionsObservation(tc.conditions)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateQualityGateConditionsObservation() mismatch (-want +got):\n%s", diff)
@@ -117,6 +125,8 @@ func TestGenerateQualityGateConditionsObservation(t *testing.T) {
 }
 
 func TestGenerateCreateQualityGateConditionOption(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		params v1alpha1.QualityGateConditionParameters
 		want   *sonar.QualitygatesCreateConditionOption
@@ -162,6 +172,8 @@ func TestGenerateCreateQualityGateConditionOption(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateCreateQualityGateConditionOption(tc.want.GateName, tc.params)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateCreateQualityGateConditionOption() mismatch (-want +got):\n%s", diff)
@@ -171,6 +183,8 @@ func TestGenerateCreateQualityGateConditionOption(t *testing.T) {
 }
 
 func TestGenerateUpdateQualityGateConditionOption(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		id     string
 		params v1alpha1.QualityGateConditionParameters
@@ -206,6 +220,8 @@ func TestGenerateUpdateQualityGateConditionOption(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateUpdateQualityGateConditionOption(tc.id, tc.params)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateUpdateQualityGateConditionOption() mismatch (-want +got):\n%s", diff)
@@ -215,6 +231,8 @@ func TestGenerateUpdateQualityGateConditionOption(t *testing.T) {
 }
 
 func TestGenerateDeleteQualityGateConditionOption(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		id   string
 		want *sonar.QualitygatesDeleteConditionOption
@@ -231,6 +249,8 @@ func TestGenerateDeleteQualityGateConditionOption(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateDeleteQualityGateConditionOption(tc.id)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateDeleteQualityGateConditionOption() mismatch (-want +got):\n%s", diff)
@@ -240,6 +260,8 @@ func TestGenerateDeleteQualityGateConditionOption(t *testing.T) {
 }
 
 func TestIsQualityGateConditionUpToDate(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		params      *v1alpha1.QualityGateConditionParameters
 		observation *v1alpha1.QualityGateConditionObservation
@@ -322,6 +344,8 @@ func TestIsQualityGateConditionUpToDate(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsQualityGateConditionUpToDate(tc.params, tc.observation)
 			if got != tc.want {
 				t.Errorf("IsQualityGateConditionUpToDate() = %v, want %v", got, tc.want)
@@ -331,6 +355,8 @@ func TestIsQualityGateConditionUpToDate(t *testing.T) {
 }
 
 func TestLateInitializeQualityGateCondition(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		params      *v1alpha1.QualityGateConditionParameters
 		observation *v1alpha1.QualityGateConditionObservation
@@ -360,6 +386,8 @@ func TestLateInitializeQualityGateCondition(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			LateInitializeQualityGateCondition(tc.params, tc.observation)
 
 			if tc.params == nil {
@@ -386,6 +414,8 @@ func TestLateInitializeQualityGateCondition(t *testing.T) {
 }
 
 func TestGenerateQualityGateConditionsAssociation(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		specs        []v1alpha1.QualityGateConditionParameters
 		observations []v1alpha1.QualityGateConditionObservation
@@ -435,6 +465,8 @@ func TestGenerateQualityGateConditionsAssociation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateConditionsAssociation(tc.specs, tc.observations)
 			if len(got) != len(tc.wantKeys) {
 				t.Errorf("GenerateQualityGateConditionsAssociation() returned %d associations, want %d", len(got), len(tc.wantKeys))
@@ -450,6 +482,8 @@ func TestGenerateQualityGateConditionsAssociation(t *testing.T) {
 }
 
 func TestAreQualityGateConditionsUpToDate(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		associations map[string]QualityGateConditionAssociation
 		want         bool
@@ -486,6 +520,8 @@ func TestAreQualityGateConditionsUpToDate(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := AreQualityGateConditionsUpToDate(tc.associations)
 			if got != tc.want {
 				t.Errorf("AreQualityGateConditionsUpToDate() = %v, want %v", got, tc.want)
@@ -495,6 +531,8 @@ func TestAreQualityGateConditionsUpToDate(t *testing.T) {
 }
 
 func TestFindNonExistingQualityGateConditions(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		associations map[string]QualityGateConditionAssociation
 		wantCount    int
@@ -538,6 +576,8 @@ func TestFindNonExistingQualityGateConditions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := FindNonExistingQualityGateConditions(tc.associations)
 			if len(got) != tc.wantCount {
 				t.Errorf("FindNonExistingQualityGateConditions() returned %d, want %d", len(got), tc.wantCount)
@@ -547,6 +587,8 @@ func TestFindNonExistingQualityGateConditions(t *testing.T) {
 }
 
 func TestFindMissingQualityGateConditions(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		associations map[string]QualityGateConditionAssociation
 		wantCount    int
@@ -590,6 +632,8 @@ func TestFindMissingQualityGateConditions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := FindMissingQualityGateConditions(tc.associations)
 			if len(got) != tc.wantCount {
 				t.Errorf("FindMissingQualityGateConditions() returned %d, want %d", len(got), tc.wantCount)
@@ -599,6 +643,8 @@ func TestFindMissingQualityGateConditions(t *testing.T) {
 }
 
 func TestFindNotUpToDateQualityGateConditions(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		associations map[string]QualityGateConditionAssociation
 		wantCount    int
@@ -651,6 +697,8 @@ func TestFindNotUpToDateQualityGateConditions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := FindNotUpToDateQualityGateConditions(tc.associations)
 			if len(got) != tc.wantCount {
 				t.Errorf("FindNotUpToDateQualityGateConditions() returned %d, want %d", len(got), tc.wantCount)
@@ -660,6 +708,8 @@ func TestFindNotUpToDateQualityGateConditions(t *testing.T) {
 }
 
 func TestGenerateQualityGateConditionObservationFromCreate(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		condition *sonar.QualitygatesCreateCondition
 		want      *v1alpha1.QualityGateConditionObservation
@@ -686,6 +736,8 @@ func TestGenerateQualityGateConditionObservationFromCreate(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateConditionObservationFromCreate(tc.condition)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateQualityGateConditionObservationFromCreate() mismatch (-want +got):\n%s", diff)

--- a/internal/clients/instance/qualitygate_condition_test.go
+++ b/internal/clients/instance/qualitygate_condition_test.go
@@ -361,17 +361,23 @@ func TestLateInitializeQualityGateCondition(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			LateInitializeQualityGateCondition(tc.params, tc.observation)
+
 			if tc.params == nil {
 				return
 			}
+
 			if tc.wantOp == nil && tc.params.Op != nil {
 				t.Errorf("LateInitializeQualityGateCondition() Op = %v, want nil", *tc.params.Op)
+
 				return
 			}
+
 			if tc.wantOp != nil && tc.params.Op == nil {
 				t.Errorf("LateInitializeQualityGateCondition() Op = nil, want %v", *tc.wantOp)
+
 				return
 			}
+
 			if tc.wantOp != nil && tc.params.Op != nil && *tc.params.Op != *tc.wantOp {
 				t.Errorf("LateInitializeQualityGateCondition() Op = %v, want %v", *tc.params.Op, *tc.wantOp)
 			}
@@ -433,6 +439,7 @@ func TestGenerateQualityGateConditionsAssociation(t *testing.T) {
 			if len(got) != len(tc.wantKeys) {
 				t.Errorf("GenerateQualityGateConditionsAssociation() returned %d associations, want %d", len(got), len(tc.wantKeys))
 			}
+
 			for _, key := range tc.wantKeys {
 				if _, exists := got[key]; !exists {
 					t.Errorf("GenerateQualityGateConditionsAssociation() missing key %q", key)

--- a/internal/clients/instance/qualitygate_test.go
+++ b/internal/clients/instance/qualitygate_test.go
@@ -483,17 +483,23 @@ func TestLateInitializeQualityGate(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			LateInitializeQualityGate(tc.spec, tc.observation)
+
 			if tc.spec == nil {
 				return
 			}
+
 			if tc.wantDefault == nil && tc.spec.Default != nil {
 				t.Errorf("LateInitializeQualityGate() Default = %v, want nil", *tc.spec.Default)
+
 				return
 			}
+
 			if tc.wantDefault != nil && tc.spec.Default == nil {
 				t.Errorf("LateInitializeQualityGate() Default = nil, want %v", *tc.wantDefault)
+
 				return
 			}
+
 			if tc.wantDefault != nil && tc.spec.Default != nil && *tc.spec.Default != *tc.wantDefault {
 				t.Errorf("LateInitializeQualityGate() Default = %v, want %v", *tc.spec.Default, *tc.wantDefault)
 			}

--- a/internal/clients/instance/qualitygate_test.go
+++ b/internal/clients/instance/qualitygate_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestGenerateQualityGateCreateOptions(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		spec v1alpha1.QualityGateParameters
 		want *sonar.QualitygatesCreateOption
@@ -52,6 +54,8 @@ func TestGenerateQualityGateCreateOptions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateCreateOptions(tc.spec)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateQualityGateCreateOptions() mismatch (-want +got):\n%s", diff)
@@ -61,6 +65,8 @@ func TestGenerateQualityGateCreateOptions(t *testing.T) {
 }
 
 func TestGenerateQualityGateObservation(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		observation *sonar.QualitygatesShow
 		want        v1alpha1.QualityGateObservation
@@ -151,6 +157,8 @@ func TestGenerateQualityGateObservation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateObservation(tc.observation)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateQualityGateObservation() mismatch (-want +got):\n%s", diff)
@@ -160,6 +168,8 @@ func TestGenerateQualityGateObservation(t *testing.T) {
 }
 
 func TestGenerateQualityGateActionsObservation(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		actions *sonar.QualityGateActions
 		want    v1alpha1.QualityGatesActions
@@ -204,6 +214,8 @@ func TestGenerateQualityGateActionsObservation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := GenerateQualityGateActionsObservation(tc.actions)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GenerateQualityGateActionsObservation() mismatch (-want +got):\n%s", diff)
@@ -213,6 +225,8 @@ func TestGenerateQualityGateActionsObservation(t *testing.T) {
 }
 
 func TestIsQualityGateUpToDate(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		spec         *v1alpha1.QualityGateParameters
 		observation  *v1alpha1.QualityGateObservation
@@ -287,6 +301,8 @@ func TestIsQualityGateUpToDate(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsQualityGateUpToDate(tc.spec, tc.observation, tc.associations)
 			if got != tc.want {
 				t.Errorf("IsQualityGateUpToDate() = %v, want %v", got, tc.want)
@@ -296,6 +312,8 @@ func TestIsQualityGateUpToDate(t *testing.T) {
 }
 
 func TestLateInitializeQualityGate(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		spec           *v1alpha1.QualityGateParameters
 		observation    *v1alpha1.QualityGateObservation
@@ -482,6 +500,8 @@ func TestLateInitializeQualityGate(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			LateInitializeQualityGate(tc.spec, tc.observation)
 
 			if tc.spec == nil {
@@ -515,6 +535,8 @@ func TestLateInitializeQualityGate(t *testing.T) {
 }
 
 func TestWereQualityGateConditionsLateInitialized(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		before []v1alpha1.QualityGateConditionParameters
 		after  []v1alpha1.QualityGateConditionParameters
@@ -576,6 +598,8 @@ func TestWereQualityGateConditionsLateInitialized(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := WereQualityGateConditionsLateInitialized(tc.before, tc.after)
 			if got != tc.want {
 				t.Errorf("WereQualityGateConditionsLateInitialized() = %v, want %v", got, tc.want)

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -30,9 +30,11 @@ import (
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
 func Setup(mgr ctrl.Manager, o controller.Options) error {
-	if err := setupNamespacedProviderConfig(mgr, o); err != nil {
+	err := setupNamespacedProviderConfig(mgr, o)
+	if err != nil {
 		return err
 	}
+
 	return setupClusterProviderConfig(mgr, o)
 }
 

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -23,58 +23,70 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/provider-sonarqube/apis/v1alpha1"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	err := setupNamespacedProviderConfig(mgr, o)
+func Setup(mgr ctrl.Manager, opts controller.Options) error {
+	err := setupNamespacedProviderConfig(mgr, opts)
 	if err != nil {
 		return err
 	}
 
-	return setupClusterProviderConfig(mgr, o)
+	return setupClusterProviderConfig(mgr, opts)
 }
 
-func setupNamespacedProviderConfig(mgr ctrl.Manager, o controller.Options) error {
-	name := providerconfig.ControllerName(v1alpha1.ProviderConfigGroupKind)
+func setupNamespacedProviderConfig(mgr ctrl.Manager, opts controller.Options) error {
+	return setupProviderConfig(
+		mgr,
+		opts,
+		v1alpha1.ProviderConfigGroupKind,
+		resource.ProviderConfigKinds{
+			Config:    v1alpha1.ProviderConfigGroupVersionKind,
+			Usage:     v1alpha1.ProviderConfigUsageGroupVersionKind,
+			UsageList: v1alpha1.ProviderConfigUsageListGroupVersionKind,
+		},
+		&v1alpha1.ProviderConfig{},
+		&v1alpha1.ProviderConfigUsage{},
+	)
+}
 
-	of := resource.ProviderConfigKinds{
-		Config:    v1alpha1.ProviderConfigGroupVersionKind,
-		Usage:     v1alpha1.ProviderConfigUsageGroupVersionKind,
-		UsageList: v1alpha1.ProviderConfigUsageListGroupVersionKind,
-	}
+func setupClusterProviderConfig(mgr ctrl.Manager, opts controller.Options) error {
+	return setupProviderConfig(
+		mgr,
+		opts,
+		v1alpha1.ClusterProviderConfigGroupKind,
+		resource.ProviderConfigKinds{
+			Config:    v1alpha1.ClusterProviderConfigGroupVersionKind,
+			Usage:     v1alpha1.ClusterProviderConfigUsageGroupVersionKind,
+			UsageList: v1alpha1.ClusterProviderConfigUsageListGroupVersionKind,
+		},
+		&v1alpha1.ClusterProviderConfig{},
+		&v1alpha1.ClusterProviderConfigUsage{},
+	)
+}
 
-	r := providerconfig.NewReconciler(mgr, of,
-		providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
+func setupProviderConfig(
+	mgr ctrl.Manager,
+	opts controller.Options,
+	groupKind string,
+	kinds resource.ProviderConfigKinds,
+	config client.Object,
+	usage client.Object,
+) error {
+	name := providerconfig.ControllerName(groupKind)
+
+	reconciler := providerconfig.NewReconciler(mgr, kinds,
+		providerconfig.WithLogger(opts.Logger.WithValues("controller", name)),
 		providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(o.ForControllerRuntime()).
-		For(&v1alpha1.ProviderConfig{}).
-		Watches(&v1alpha1.ProviderConfigUsage{}, &resource.EnqueueRequestForProviderConfig{}).
-		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
-}
-
-func setupClusterProviderConfig(mgr ctrl.Manager, o controller.Options) error {
-	name := providerconfig.ControllerName(v1alpha1.ClusterProviderConfigGroupKind)
-	of := resource.ProviderConfigKinds{
-		Config:    v1alpha1.ClusterProviderConfigGroupVersionKind,
-		Usage:     v1alpha1.ClusterProviderConfigUsageGroupVersionKind,
-		UsageList: v1alpha1.ClusterProviderConfigUsageListGroupVersionKind,
-	}
-
-	r := providerconfig.NewReconciler(mgr, of,
-		providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
-		providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
-
-	return ctrl.NewControllerManagedBy(mgr).
-		Named(name).
-		WithOptions(o.ForControllerRuntime()).
-		For(&v1alpha1.ClusterProviderConfig{}).
-		Watches(&v1alpha1.ClusterProviderConfigUsage{}, &resource.EnqueueRequestForProviderConfig{}).
-		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+		WithOptions(opts.ForControllerRuntime()).
+		For(config).
+		Watches(usage, &resource.EnqueueRequestForProviderConfig{}).
+		Complete(ratelimiter.NewReconciler(name, reconciler, opts.GlobalRateLimiter))
 }

--- a/internal/controller/qualitygate/qualitygate_test.go
+++ b/internal/controller/qualitygate/qualitygate_test.go
@@ -47,7 +47,17 @@ type notQualityGate struct {
 	resource.Managed
 }
 
+// mockHTTPResponse returns a mock HTTP response for testing.
+func mockHTTPResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+	}
+}
+
 func TestObserve(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
@@ -245,6 +255,8 @@ func TestObserve(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			e := &external{qualityGatesClient: tc.client}
 			got, err := e.Observe(tc.args.ctx, tc.args.mg)
 
@@ -260,6 +272,8 @@ func TestObserve(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
@@ -372,7 +386,7 @@ func TestCreate(t *testing.T) {
 						return nil, errors.New("expected SonarQube gate name but got: " + opt.Name)
 					}
 
-					return nil, nil
+					return mockHTTPResponse(), nil
 				},
 			},
 			args: args{
@@ -425,6 +439,8 @@ func TestCreate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			e := &external{qualityGatesClient: tc.client}
 			got, err := e.Create(tc.args.ctx, tc.args.mg)
 
@@ -440,6 +456,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
@@ -485,7 +503,7 @@ func TestUpdate(t *testing.T) {
 		"SetAsDefaultWhenRequested": {
 			client: &fake.MockQualityGatesClient{
 				SetAsDefaultFn: func(opt *sonar.QualitygatesSetAsDefaultOption) (*http.Response, error) {
-					return nil, nil
+					return mockHTTPResponse(), nil
 				},
 			},
 			args: args{
@@ -548,6 +566,8 @@ func TestUpdate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			e := &external{qualityGatesClient: tc.client}
 			got, err := e.Update(tc.args.ctx, tc.args.mg)
 
@@ -563,6 +583,8 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
@@ -613,7 +635,7 @@ func TestDelete(t *testing.T) {
 						return nil, errors.New("expected external name 'my-sonar-gate' but got: " + opt.Name)
 					}
 
-					return nil, nil
+					return mockHTTPResponse(), nil
 				},
 			},
 			args: args{
@@ -664,6 +686,8 @@ func TestDelete(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			e := &external{qualityGatesClient: tc.client}
 			got, err := e.Delete(tc.args.ctx, tc.args.mg)
 
@@ -679,6 +703,8 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDisconnect(t *testing.T) {
+	t.Parallel()
+
 	e := &external{qualityGatesClient: &fake.MockQualityGatesClient{}}
 
 	err := e.Disconnect(context.Background())
@@ -688,6 +714,8 @@ func TestDisconnect(t *testing.T) {
 }
 
 func TestCreateSetsExternalNameToSonarQubeName(t *testing.T) {
+	t.Parallel()
+
 	client := &fake.MockQualityGatesClient{
 		CreateFn: func(opt *sonar.QualitygatesCreateOption) (*sonar.QualitygatesCreate, *http.Response, error) {
 			return &sonar.QualitygatesCreate{
@@ -734,6 +762,8 @@ func errComparer(a, b error) bool {
 }
 
 func TestObserveLateInitializesConditionIds(t *testing.T) {
+	t.Parallel()
+
 	client := &fake.MockQualityGatesClient{
 		ShowFn: func(opt *sonar.QualitygatesShowOption) (*sonar.QualitygatesShow, *http.Response, error) {
 			return &sonar.QualitygatesShow{
@@ -804,6 +834,8 @@ func TestObserveLateInitializesConditionIds(t *testing.T) {
 }
 
 func TestObserveWithExistingConditionIds(t *testing.T) {
+	t.Parallel()
+
 	client := &fake.MockQualityGatesClient{
 		ShowFn: func(opt *sonar.QualitygatesShowOption) (*sonar.QualitygatesShow, *http.Response, error) {
 			return &sonar.QualitygatesShow{
@@ -862,6 +894,8 @@ func TestObserveWithExistingConditionIds(t *testing.T) {
 }
 
 func TestObserveWithStaleConditionId(t *testing.T) {
+	t.Parallel()
+
 	client := &fake.MockQualityGatesClient{
 		ShowFn: func(opt *sonar.QualitygatesShowOption) (*sonar.QualitygatesShow, *http.Response, error) {
 			return &sonar.QualitygatesShow{
@@ -920,6 +954,8 @@ func TestObserveWithStaleConditionId(t *testing.T) {
 }
 
 func TestUpdateWithConditions(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
@@ -980,7 +1016,7 @@ func TestUpdateWithConditions(t *testing.T) {
 						return nil, errors.New("expected to delete orphan-id")
 					}
 
-					return nil, nil
+					return mockHTTPResponse(), nil
 				},
 			},
 			args: args{
@@ -1130,6 +1166,8 @@ func TestUpdateWithConditions(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			e := &external{qualityGatesClient: tc.client}
 			got, err := e.Update(tc.args.ctx, tc.args.mg)
 
@@ -1146,6 +1184,8 @@ func TestUpdateWithConditions(t *testing.T) {
 }
 
 func TestObserveWithConditions(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
@@ -1349,6 +1389,8 @@ func TestObserveWithConditions(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			e := &external{qualityGatesClient: tc.client}
 			got, err := e.Observe(tc.args.ctx, tc.args.mg)
 

--- a/internal/controller/qualitygate/qualitygate_test.go
+++ b/internal/controller/qualitygate/qualitygate_test.go
@@ -52,6 +52,7 @@ func TestObserve(t *testing.T) {
 		ctx context.Context
 		mg  resource.Managed
 	}
+
 	type want struct {
 		o   managed.ExternalObservation
 		err error
@@ -105,6 +106,7 @@ func TestObserve(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -142,6 +144,7 @@ func TestObserve(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -183,6 +186,7 @@ func TestObserve(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -224,6 +228,7 @@ func TestObserve(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -246,6 +251,7 @@ func TestObserve(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(errComparer)); diff != "" {
 				t.Errorf("Observe() error mismatch (-want +got):\n%s", diff)
 			}
+
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Observe() mismatch (-want +got):\n%s", diff)
 			}
@@ -258,6 +264,7 @@ func TestCreate(t *testing.T) {
 		ctx context.Context
 		mg  resource.Managed
 	}
+
 	type want struct {
 		o   managed.ExternalCreation
 		err error
@@ -364,6 +371,7 @@ func TestCreate(t *testing.T) {
 					if opt.Name != "my-sonar-gate" {
 						return nil, errors.New("expected SonarQube gate name but got: " + opt.Name)
 					}
+
 					return nil, nil
 				},
 			},
@@ -423,6 +431,7 @@ func TestCreate(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(errComparer)); diff != "" {
 				t.Errorf("Create() error mismatch (-want +got):\n%s", diff)
 			}
+
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Create() mismatch (-want +got):\n%s", diff)
 			}
@@ -435,6 +444,7 @@ func TestUpdate(t *testing.T) {
 		ctx context.Context
 		mg  resource.Managed
 	}
+
 	type want struct {
 		o   managed.ExternalUpdate
 		err error
@@ -494,6 +504,7 @@ func TestUpdate(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -524,6 +535,7 @@ func TestUpdate(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -542,6 +554,7 @@ func TestUpdate(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(errComparer)); diff != "" {
 				t.Errorf("Update() error mismatch (-want +got):\n%s", diff)
 			}
+
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Update() mismatch (-want +got):\n%s", diff)
 			}
@@ -554,6 +567,7 @@ func TestDelete(t *testing.T) {
 		ctx context.Context
 		mg  resource.Managed
 	}
+
 	type want struct {
 		o   managed.ExternalDelete
 		err error
@@ -598,6 +612,7 @@ func TestDelete(t *testing.T) {
 					if opt.Name != "my-sonar-gate" {
 						return nil, errors.New("expected external name 'my-sonar-gate' but got: " + opt.Name)
 					}
+
 					return nil, nil
 				},
 			},
@@ -611,6 +626,7 @@ func TestDelete(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "my-sonar-gate") // this should be used for deletion
+
 					return qg
 				}(),
 			},
@@ -635,6 +651,7 @@ func TestDelete(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -653,6 +670,7 @@ func TestDelete(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(errComparer)); diff != "" {
 				t.Errorf("Delete() error mismatch (-want +got):\n%s", diff)
 			}
+
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Delete() mismatch (-want +got):\n%s", diff)
 			}
@@ -662,6 +680,7 @@ func TestDelete(t *testing.T) {
 
 func TestDisconnect(t *testing.T) {
 	e := &external{qualityGatesClient: &fake.MockQualityGatesClient{}}
+
 	err := e.Disconnect(context.Background())
 	if err != nil {
 		t.Errorf("Disconnect() error = %v, want nil", err)
@@ -688,6 +707,7 @@ func TestCreateSetsExternalNameToSonarQubeName(t *testing.T) {
 	}
 
 	e := &external{qualityGatesClient: client}
+
 	_, err := e.Create(context.Background(), qg)
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
@@ -700,14 +720,16 @@ func TestCreateSetsExternalNameToSonarQubeName(t *testing.T) {
 	}
 }
 
-// errComparer compares errors by their message
+// errComparer compares errors by their message.
 func errComparer(a, b error) bool {
 	if a == nil && b == nil {
 		return true
 	}
+
 	if a == nil || b == nil {
 		return false
 	}
+
 	return a.Error() == b.Error()
 }
 
@@ -747,6 +769,7 @@ func TestObserveLateInitializesConditionIds(t *testing.T) {
 	meta.SetExternalName(qg, "test-gate")
 
 	e := &external{qualityGatesClient: client}
+
 	obs, err := e.Observe(context.Background(), qg)
 	if err != nil {
 		t.Fatalf("Observe() error = %v", err)
@@ -814,6 +837,7 @@ func TestObserveWithExistingConditionIds(t *testing.T) {
 	meta.SetExternalName(qg, "test-gate")
 
 	e := &external{qualityGatesClient: client}
+
 	obs, err := e.Observe(context.Background(), qg)
 	if err != nil {
 		t.Fatalf("Observe() error = %v", err)
@@ -871,6 +895,7 @@ func TestObserveWithStaleConditionId(t *testing.T) {
 	meta.SetExternalName(qg, "test-gate")
 
 	e := &external{qualityGatesClient: client}
+
 	obs, err := e.Observe(context.Background(), qg)
 	if err != nil {
 		t.Fatalf("Observe() error = %v", err)
@@ -899,6 +924,7 @@ func TestUpdateWithConditions(t *testing.T) {
 		ctx context.Context
 		mg  resource.Managed
 	}
+
 	type want struct {
 		o   managed.ExternalUpdate
 		err error
@@ -938,6 +964,7 @@ func TestUpdateWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -952,6 +979,7 @@ func TestUpdateWithConditions(t *testing.T) {
 					if opt.ID != "orphan-id" {
 						return nil, errors.New("expected to delete orphan-id")
 					}
+
 					return nil, nil
 				},
 			},
@@ -978,6 +1006,7 @@ func TestUpdateWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1017,6 +1046,7 @@ func TestUpdateWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1049,6 +1079,7 @@ func TestUpdateWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1086,6 +1117,7 @@ func TestUpdateWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1104,6 +1136,7 @@ func TestUpdateWithConditions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(errComparer)); diff != "" {
 				t.Errorf("Update() error mismatch (-want +got):\n%s", diff)
 			}
+
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Update() mismatch (-want +got):\n%s", diff)
 			}
@@ -1117,6 +1150,7 @@ func TestObserveWithConditions(t *testing.T) {
 		ctx context.Context
 		mg  resource.Managed
 	}
+
 	type want struct {
 		o   managed.ExternalObservation
 		err error
@@ -1161,6 +1195,7 @@ func TestObserveWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1207,6 +1242,7 @@ func TestObserveWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1251,6 +1287,7 @@ func TestObserveWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1295,6 +1332,7 @@ func TestObserveWithConditions(t *testing.T) {
 						},
 					}
 					meta.SetExternalName(qg, "test-gate")
+
 					return qg
 				}(),
 			},
@@ -1317,6 +1355,7 @@ func TestObserveWithConditions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(errComparer)); diff != "" {
 				t.Errorf("Observe() error mismatch (-want +got):\n%s", diff)
 			}
+
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Observe() mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/controller/register.go
+++ b/internal/controller/register.go
@@ -31,9 +31,11 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 		config.Setup,
 		qualitygate.SetupGated,
 	} {
-		if err := setup(mgr, o); err != nil {
+		err := setup(mgr, o)
+		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/internal/fake/qualitygates_client.go
+++ b/internal/fake/qualitygates_client.go
@@ -49,173 +49,194 @@ type MockQualityGatesClient struct {
 	UpdateConditionFn func(opt *sonar.QualitygatesUpdateConditionOption) (resp *http.Response, err error)
 }
 
-// Ensure MockQualityGatesClient implements QualityGatesClient
+// Ensure MockQualityGatesClient implements QualityGatesClient.
 var _ instance.QualityGatesClient = &MockQualityGatesClient{}
 
-// AddGroup implements QualityGatesClient.AddGroup
+// AddGroup implements QualityGatesClient.AddGroup.
 func (m *MockQualityGatesClient) AddGroup(opt *sonar.QualitygatesAddGroupOption) (resp *http.Response, err error) {
 	if m.AddGroupFn != nil {
 		return m.AddGroupFn(opt)
 	}
+
 	return nil, nil
 }
 
-// AddUser implements QualityGatesClient.AddUser
+// AddUser implements QualityGatesClient.AddUser.
 func (m *MockQualityGatesClient) AddUser(opt *sonar.QualitygatesAddUserOption) (resp *http.Response, err error) {
 	if m.AddUserFn != nil {
 		return m.AddUserFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Copy implements QualityGatesClient.Copy
+// Copy implements QualityGatesClient.Copy.
 func (m *MockQualityGatesClient) Copy(opt *sonar.QualitygatesCopyOption) (resp *http.Response, err error) {
 	if m.CopyFn != nil {
 		return m.CopyFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Create implements QualityGatesClient.Create
+// Create implements QualityGatesClient.Create.
 func (m *MockQualityGatesClient) Create(opt *sonar.QualitygatesCreateOption) (v *sonar.QualitygatesCreate, resp *http.Response, err error) {
 	if m.CreateFn != nil {
 		return m.CreateFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// CreateCondition implements QualityGatesClient.CreateCondition
+// CreateCondition implements QualityGatesClient.CreateCondition.
 func (m *MockQualityGatesClient) CreateCondition(opt *sonar.QualitygatesCreateConditionOption) (v *sonar.QualitygatesCreateCondition, resp *http.Response, err error) {
 	if m.CreateConditionFn != nil {
 		return m.CreateConditionFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// DeleteCondition implements QualityGatesClient.DeleteCondition
+// DeleteCondition implements QualityGatesClient.DeleteCondition.
 func (m *MockQualityGatesClient) DeleteCondition(opt *sonar.QualitygatesDeleteConditionOption) (resp *http.Response, err error) {
 	if m.DeleteConditionFn != nil {
 		return m.DeleteConditionFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Deselect implements QualityGatesClient.Deselect
+// Deselect implements QualityGatesClient.Deselect.
 func (m *MockQualityGatesClient) Deselect(opt *sonar.QualitygatesDeselectOption) (resp *http.Response, err error) {
 	if m.DeselectFn != nil {
 		return m.DeselectFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Destroy implements QualityGatesClient.Destroy
+// Destroy implements QualityGatesClient.Destroy.
 func (m *MockQualityGatesClient) Destroy(opt *sonar.QualitygatesDestroyOption) (resp *http.Response, err error) {
 	if m.DestroyFn != nil {
 		return m.DestroyFn(opt)
 	}
+
 	return nil, nil
 }
 
-// GetByProject implements QualityGatesClient.GetByProject
+// GetByProject implements QualityGatesClient.GetByProject.
 func (m *MockQualityGatesClient) GetByProject(opt *sonar.QualitygatesGetByProjectOption) (v *sonar.QualitygatesGetByProject, resp *http.Response, err error) {
 	if m.GetByProjectFn != nil {
 		return m.GetByProjectFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// List implements QualityGatesClient.List
+// List implements QualityGatesClient.List.
 func (m *MockQualityGatesClient) List() (v *sonar.QualitygatesList, resp *http.Response, err error) {
 	if m.ListFn != nil {
 		return m.ListFn()
 	}
+
 	return nil, nil, nil
 }
 
-// ProjectStatus implements QualityGatesClient.ProjectStatus
+// ProjectStatus implements QualityGatesClient.ProjectStatus.
 func (m *MockQualityGatesClient) ProjectStatus(opt *sonar.QualitygatesProjectStatusOption) (v *sonar.QualitygatesProjectStatus, resp *http.Response, err error) {
 	if m.ProjectStatusFn != nil {
 		return m.ProjectStatusFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// RemoveGroup implements QualityGatesClient.RemoveGroup
+// RemoveGroup implements QualityGatesClient.RemoveGroup.
 func (m *MockQualityGatesClient) RemoveGroup(opt *sonar.QualitygatesRemoveGroupOption) (resp *http.Response, err error) {
 	if m.RemoveGroupFn != nil {
 		return m.RemoveGroupFn(opt)
 	}
+
 	return nil, nil
 }
 
-// RemoveUser implements QualityGatesClient.RemoveUser
+// RemoveUser implements QualityGatesClient.RemoveUser.
 func (m *MockQualityGatesClient) RemoveUser(opt *sonar.QualitygatesRemoveUserOption) (resp *http.Response, err error) {
 	if m.RemoveUserFn != nil {
 		return m.RemoveUserFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Rename implements QualityGatesClient.Rename
+// Rename implements QualityGatesClient.Rename.
 func (m *MockQualityGatesClient) Rename(opt *sonar.QualitygatesRenameOption) (resp *http.Response, err error) {
 	if m.RenameFn != nil {
 		return m.RenameFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Search implements QualityGatesClient.Search
+// Search implements QualityGatesClient.Search.
 func (m *MockQualityGatesClient) Search(opt *sonar.QualitygatesSearchOption) (v *sonar.QualitygatesSearch, resp *http.Response, err error) {
 	if m.SearchFn != nil {
 		return m.SearchFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// SearchGroups implements QualityGatesClient.SearchGroups
+// SearchGroups implements QualityGatesClient.SearchGroups.
 func (m *MockQualityGatesClient) SearchGroups(opt *sonar.QualitygatesSearchGroupsOption) (v *sonar.QualitygatesSearchGroups, resp *http.Response, err error) {
 	if m.SearchGroupsFn != nil {
 		return m.SearchGroupsFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// SearchUsers implements QualityGatesClient.SearchUsers
+// SearchUsers implements QualityGatesClient.SearchUsers.
 func (m *MockQualityGatesClient) SearchUsers(opt *sonar.QualitygatesSearchUsersOption) (v *sonar.QualitygatesSearchUsers, resp *http.Response, err error) {
 	if m.SearchUsersFn != nil {
 		return m.SearchUsersFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// Select implements QualityGatesClient.Select
+// Select implements QualityGatesClient.Select.
 func (m *MockQualityGatesClient) Select(opt *sonar.QualitygatesSelectOption) (resp *http.Response, err error) {
 	if m.SelectFn != nil {
 		return m.SelectFn(opt)
 	}
+
 	return nil, nil
 }
 
-// SetAsDefault implements QualityGatesClient.SetAsDefault
+// SetAsDefault implements QualityGatesClient.SetAsDefault.
 func (m *MockQualityGatesClient) SetAsDefault(opt *sonar.QualitygatesSetAsDefaultOption) (resp *http.Response, err error) {
 	if m.SetAsDefaultFn != nil {
 		return m.SetAsDefaultFn(opt)
 	}
+
 	return nil, nil
 }
 
-// Show implements QualityGatesClient.Show
+// Show implements QualityGatesClient.Show.
 func (m *MockQualityGatesClient) Show(opt *sonar.QualitygatesShowOption) (v *sonar.QualitygatesShow, resp *http.Response, err error) {
 	if m.ShowFn != nil {
 		return m.ShowFn(opt)
 	}
+
 	return nil, nil, nil
 }
 
-// UpdateCondition implements QualityGatesClient.UpdateCondition
+// UpdateCondition implements QualityGatesClient.UpdateCondition.
 func (m *MockQualityGatesClient) UpdateCondition(opt *sonar.QualitygatesUpdateConditionOption) (resp *http.Response, err error) {
 	if m.UpdateConditionFn != nil {
 		return m.UpdateConditionFn(opt)
 	}
+
 	return nil, nil
 }

--- a/internal/fake/qualitygates_client.go
+++ b/internal/fake/qualitygates_client.go
@@ -18,11 +18,14 @@ limitations under the License.
 package fake
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/boxboxjason/sonarqube-client-go/sonar"
 	"github.com/crossplane/provider-sonarqube/internal/clients/instance"
 )
+
+var errNotImplemented = errors.New("mock function not implemented")
 
 // MockQualityGatesClient is a mock implementation of the QualityGatesClient interface.
 type MockQualityGatesClient struct {
@@ -58,7 +61,7 @@ func (m *MockQualityGatesClient) AddGroup(opt *sonar.QualitygatesAddGroupOption)
 		return m.AddGroupFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // AddUser implements QualityGatesClient.AddUser.
@@ -67,7 +70,7 @@ func (m *MockQualityGatesClient) AddUser(opt *sonar.QualitygatesAddUserOption) (
 		return m.AddUserFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Copy implements QualityGatesClient.Copy.
@@ -76,7 +79,7 @@ func (m *MockQualityGatesClient) Copy(opt *sonar.QualitygatesCopyOption) (resp *
 		return m.CopyFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Create implements QualityGatesClient.Create.
@@ -85,7 +88,7 @@ func (m *MockQualityGatesClient) Create(opt *sonar.QualitygatesCreateOption) (v 
 		return m.CreateFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // CreateCondition implements QualityGatesClient.CreateCondition.
@@ -94,7 +97,7 @@ func (m *MockQualityGatesClient) CreateCondition(opt *sonar.QualitygatesCreateCo
 		return m.CreateConditionFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // DeleteCondition implements QualityGatesClient.DeleteCondition.
@@ -103,7 +106,7 @@ func (m *MockQualityGatesClient) DeleteCondition(opt *sonar.QualitygatesDeleteCo
 		return m.DeleteConditionFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Deselect implements QualityGatesClient.Deselect.
@@ -112,7 +115,7 @@ func (m *MockQualityGatesClient) Deselect(opt *sonar.QualitygatesDeselectOption)
 		return m.DeselectFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Destroy implements QualityGatesClient.Destroy.
@@ -121,7 +124,7 @@ func (m *MockQualityGatesClient) Destroy(opt *sonar.QualitygatesDestroyOption) (
 		return m.DestroyFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // GetByProject implements QualityGatesClient.GetByProject.
@@ -130,7 +133,7 @@ func (m *MockQualityGatesClient) GetByProject(opt *sonar.QualitygatesGetByProjec
 		return m.GetByProjectFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // List implements QualityGatesClient.List.
@@ -139,7 +142,7 @@ func (m *MockQualityGatesClient) List() (v *sonar.QualitygatesList, resp *http.R
 		return m.ListFn()
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // ProjectStatus implements QualityGatesClient.ProjectStatus.
@@ -148,7 +151,7 @@ func (m *MockQualityGatesClient) ProjectStatus(opt *sonar.QualitygatesProjectSta
 		return m.ProjectStatusFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // RemoveGroup implements QualityGatesClient.RemoveGroup.
@@ -157,7 +160,7 @@ func (m *MockQualityGatesClient) RemoveGroup(opt *sonar.QualitygatesRemoveGroupO
 		return m.RemoveGroupFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // RemoveUser implements QualityGatesClient.RemoveUser.
@@ -166,7 +169,7 @@ func (m *MockQualityGatesClient) RemoveUser(opt *sonar.QualitygatesRemoveUserOpt
 		return m.RemoveUserFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Rename implements QualityGatesClient.Rename.
@@ -175,7 +178,7 @@ func (m *MockQualityGatesClient) Rename(opt *sonar.QualitygatesRenameOption) (re
 		return m.RenameFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Search implements QualityGatesClient.Search.
@@ -184,7 +187,7 @@ func (m *MockQualityGatesClient) Search(opt *sonar.QualitygatesSearchOption) (v 
 		return m.SearchFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // SearchGroups implements QualityGatesClient.SearchGroups.
@@ -193,7 +196,7 @@ func (m *MockQualityGatesClient) SearchGroups(opt *sonar.QualitygatesSearchGroup
 		return m.SearchGroupsFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // SearchUsers implements QualityGatesClient.SearchUsers.
@@ -202,7 +205,7 @@ func (m *MockQualityGatesClient) SearchUsers(opt *sonar.QualitygatesSearchUsersO
 		return m.SearchUsersFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // Select implements QualityGatesClient.Select.
@@ -211,7 +214,7 @@ func (m *MockQualityGatesClient) Select(opt *sonar.QualitygatesSelectOption) (re
 		return m.SelectFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // SetAsDefault implements QualityGatesClient.SetAsDefault.
@@ -220,7 +223,7 @@ func (m *MockQualityGatesClient) SetAsDefault(opt *sonar.QualitygatesSetAsDefaul
 		return m.SetAsDefaultFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 // Show implements QualityGatesClient.Show.
@@ -229,7 +232,7 @@ func (m *MockQualityGatesClient) Show(opt *sonar.QualitygatesShowOption) (v *son
 		return m.ShowFn(opt)
 	}
 
-	return nil, nil, nil
+	return nil, nil, errNotImplemented
 }
 
 // UpdateCondition implements QualityGatesClient.UpdateCondition.
@@ -238,5 +241,5 @@ func (m *MockQualityGatesClient) UpdateCondition(opt *sonar.QualitygatesUpdateCo
 		return m.UpdateConditionFn(opt)
 	}
 
-	return nil, nil
+	return nil, errNotImplemented
 }

--- a/internal/helpers/formats_test.go
+++ b/internal/helpers/formats_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestIsComparablePtrEqualComparable(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		ptr  *string
 		val  string
@@ -57,6 +59,8 @@ func TestIsComparablePtrEqualComparable(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsComparablePtrEqualComparable(tc.ptr, tc.val)
 			if got != tc.want {
 				t.Errorf("IsComparablePtrEqualComparable() = %v, want %v", got, tc.want)
@@ -66,6 +70,8 @@ func TestIsComparablePtrEqualComparable(t *testing.T) {
 }
 
 func TestIsComparablePtrEqualComparableInt(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		ptr  *int
 		val  int
@@ -95,6 +101,8 @@ func TestIsComparablePtrEqualComparableInt(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsComparablePtrEqualComparable(tc.ptr, tc.val)
 			if got != tc.want {
 				t.Errorf("IsComparablePtrEqualComparable() = %v, want %v", got, tc.want)
@@ -104,6 +112,8 @@ func TestIsComparablePtrEqualComparableInt(t *testing.T) {
 }
 
 func TestIsComparablePtrEqualComparablePtr(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		ptr1 *string
 		ptr2 *string
@@ -143,6 +153,8 @@ func TestIsComparablePtrEqualComparablePtr(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsComparablePtrEqualComparablePtr(tc.ptr1, tc.ptr2)
 			if got != tc.want {
 				t.Errorf("IsComparablePtrEqualComparablePtr() = %v, want %v", got, tc.want)
@@ -152,6 +164,8 @@ func TestIsComparablePtrEqualComparablePtr(t *testing.T) {
 }
 
 func TestIsComparablePtrEqualComparablePtrInt(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		ptr1 *int
 		ptr2 *int
@@ -186,6 +200,8 @@ func TestIsComparablePtrEqualComparablePtrInt(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsComparablePtrEqualComparablePtr(tc.ptr1, tc.ptr2)
 			if got != tc.want {
 				t.Errorf("IsComparablePtrEqualComparablePtr() = %v, want %v", got, tc.want)
@@ -195,12 +211,18 @@ func TestIsComparablePtrEqualComparablePtrInt(t *testing.T) {
 }
 
 func TestAssignIfNil(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NilOuterPointerDoesNothing", func(t *testing.T) {
+		t.Parallel()
+
 		// Should not panic
 		AssignIfNil[string](nil, "value")
 	})
 
 	t.Run("NilInnerPointerAssignsValue", func(t *testing.T) {
+		t.Parallel()
+
 		var inner *string
 		AssignIfNil(&inner, "hello")
 
@@ -214,6 +236,8 @@ func TestAssignIfNil(t *testing.T) {
 	})
 
 	t.Run("NonNilInnerPointerKeepsOriginalValue", func(t *testing.T) {
+		t.Parallel()
+
 		original := "original"
 		inner := &original
 		AssignIfNil(&inner, "new")
@@ -224,6 +248,8 @@ func TestAssignIfNil(t *testing.T) {
 	})
 
 	t.Run("IntNilInnerPointerAssignsValue", func(t *testing.T) {
+		t.Parallel()
+
 		var inner *int
 		AssignIfNil(&inner, 42)
 
@@ -237,6 +263,8 @@ func TestAssignIfNil(t *testing.T) {
 	})
 
 	t.Run("IntNonNilInnerPointerKeepsOriginalValue", func(t *testing.T) {
+		t.Parallel()
+
 		original := 100
 		inner := &original
 		AssignIfNil(&inner, 42)
@@ -247,6 +275,8 @@ func TestAssignIfNil(t *testing.T) {
 	})
 
 	t.Run("BoolNilInnerPointerAssignsValue", func(t *testing.T) {
+		t.Parallel()
+
 		var inner *bool
 		AssignIfNil(&inner, true)
 
@@ -260,6 +290,8 @@ func TestAssignIfNil(t *testing.T) {
 	})
 
 	t.Run("BoolNonNilInnerPointerKeepsOriginalValue", func(t *testing.T) {
+		t.Parallel()
+
 		original := false
 		inner := &original
 		AssignIfNil(&inner, true)

--- a/internal/helpers/formats_test.go
+++ b/internal/helpers/formats_test.go
@@ -203,9 +203,11 @@ func TestAssignIfNil(t *testing.T) {
 	t.Run("NilInnerPointerAssignsValue", func(t *testing.T) {
 		var inner *string
 		AssignIfNil(&inner, "hello")
+
 		if inner == nil {
 			t.Error("AssignIfNil() did not assign value to nil pointer")
 		}
+
 		if *inner != "hello" {
 			t.Errorf("AssignIfNil() assigned %v, want %v", *inner, "hello")
 		}
@@ -215,6 +217,7 @@ func TestAssignIfNil(t *testing.T) {
 		original := "original"
 		inner := &original
 		AssignIfNil(&inner, "new")
+
 		if *inner != "original" {
 			t.Errorf("AssignIfNil() changed value to %v, want %v", *inner, "original")
 		}
@@ -223,9 +226,11 @@ func TestAssignIfNil(t *testing.T) {
 	t.Run("IntNilInnerPointerAssignsValue", func(t *testing.T) {
 		var inner *int
 		AssignIfNil(&inner, 42)
+
 		if inner == nil {
 			t.Error("AssignIfNil() did not assign value to nil pointer")
 		}
+
 		if *inner != 42 {
 			t.Errorf("AssignIfNil() assigned %v, want %v", *inner, 42)
 		}
@@ -235,6 +240,7 @@ func TestAssignIfNil(t *testing.T) {
 		original := 100
 		inner := &original
 		AssignIfNil(&inner, 42)
+
 		if *inner != 100 {
 			t.Errorf("AssignIfNil() changed value to %v, want %v", *inner, 100)
 		}
@@ -243,9 +249,11 @@ func TestAssignIfNil(t *testing.T) {
 	t.Run("BoolNilInnerPointerAssignsValue", func(t *testing.T) {
 		var inner *bool
 		AssignIfNil(&inner, true)
+
 		if inner == nil {
 			t.Error("AssignIfNil() did not assign value to nil pointer")
 		}
+
 		if *inner != true {
 			t.Errorf("AssignIfNil() assigned %v, want %v", *inner, true)
 		}
@@ -255,6 +263,7 @@ func TestAssignIfNil(t *testing.T) {
 		original := false
 		inner := &original
 		AssignIfNil(&inner, true)
+
 		if *inner != false {
 			t.Errorf("AssignIfNil() changed value to %v, want %v", *inner, false)
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,5 +14,5 @@ limitations under the License.
 // Package version contains the version of this repo
 package version
 
-// Version will be overridden with the current version at build time using the -X linker flag
+// Version will be overridden with the current version at build time using the -X linker flag.
 var Version = "0.0.0"

--- a/package/crds/instance.sonarqube.crossplane.io_qualitygates.yaml
+++ b/package/crds/instance.sonarqube.crossplane.io_qualitygates.yaml
@@ -269,6 +269,7 @@ spec:
                     description: Name represents the name of the Quality Gate.
                     type: string
                 required:
+                - actions
                 - caycStatus
                 - isAiCodeSupported
                 - isBuiltIn
@@ -328,9 +329,13 @@ spec:
                   it can not recover from without human intervention.
                 format: int64
                 type: integer
+            required:
+            - atProvider
             type: object
         required:
+        - metadata
         - spec
+        - status
         type: object
     served: true
     storage: true

--- a/package/crds/sonarqube.crossplane.io_clusterproviderconfigs.yaml
+++ b/package/crds/sonarqube.crossplane.io_clusterproviderconfigs.yaml
@@ -29,7 +29,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ClusterProviderConfig configures a SonarQube provider.
+        description: ClusterProviderConfig configures a SonarQube provider.
         properties:
           apiVersion:
             description: |-
@@ -50,7 +50,7 @@ spec:
             type: object
           spec:
             properties:
-              baseURL:
+              baseUrl:
                 description: BaseURL of the SonarQube instance.
                 type: string
               insecureSkipVerify:
@@ -230,7 +230,7 @@ spec:
                 - source
                 type: object
             required:
-            - baseURL
+            - baseUrl
             type: object
           status:
             description: A ProviderConfigStatus defines the status of a Provider.
@@ -287,7 +287,9 @@ spec:
                 type: integer
             type: object
         required:
+        - metadata
         - spec
+        - status
         type: object
     served: true
     storage: true

--- a/package/crds/sonarqube.crossplane.io_clusterproviderconfigusages.yaml
+++ b/package/crds/sonarqube.crossplane.io_clusterproviderconfigusages.yaml
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ClusterProviderConfigUsage indicates that a resource is using
+        description: ClusterProviderConfigUsage indicates that a resource is using
           a ClusterProviderConfig.
         properties:
           apiVersion:
@@ -89,6 +89,7 @@ spec:
             - name
             type: object
         required:
+        - metadata
         - providerConfigRef
         - resourceRef
         type: object

--- a/package/crds/sonarqube.crossplane.io_providerconfigs.yaml
+++ b/package/crds/sonarqube.crossplane.io_providerconfigs.yaml
@@ -29,8 +29,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a Helm 'provider', i.e. a connection
-          to a particular
+        description: ProviderConfig configures a SonarQube provider.
         properties:
           apiVersion:
             description: |-
@@ -51,7 +50,7 @@ spec:
             type: object
           spec:
             properties:
-              baseURL:
+              baseUrl:
                 description: BaseURL of the SonarQube instance.
                 type: string
               insecureSkipVerify:
@@ -231,7 +230,7 @@ spec:
                 - source
                 type: object
             required:
-            - baseURL
+            - baseUrl
             type: object
           status:
             description: A ProviderConfigStatus defines the status of a Provider.
@@ -288,7 +287,9 @@ spec:
                 type: integer
             type: object
         required:
+        - metadata
         - spec
+        - status
         type: object
     served: true
     storage: true

--- a/package/crds/sonarqube.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/sonarqube.crossplane.io_providerconfigusages.yaml
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfigUsage indicates that a resource is using a ProviderConfig.
+        description: ProviderConfigUsage indicates that a resource is using a ProviderConfig.
         properties:
           apiVersion:
             description: |-
@@ -88,6 +88,7 @@ spec:
             - name
             type: object
         required:
+        - metadata
         - providerConfigRef
         - resourceRef
         type: object


### PR DESCRIPTION
### Description of your changes

The default crossplane (golangci-lint) linter configuration is not hard enough, preventing detection of invalid patterns.
It also does not suggest enough optimizations (for instance parallel tests).

This PR hardens the golangci-lint configuration and fixes all newly detected errors / missconfigs / style inconsistencies.
 
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have:

- [x] Successfully built and ran the provider locally against a kubernetes cluster.
- [ ] Successfully created, updated, and deleted resources of the types I changed / created.
- [ ] Ensured reconciliation loops for the changed / created resource complete without error.
  - [ ] Creation
  - [ ] Update
  - [ ] Deletion
- [ ] Deleted the resource on the app side to ensure the provider correctly handles
  unexpected drift. (should result in recreation of the resource if applicable)
- [ ] Updated the resource on the app side to ensure the provider correctly handles
  unexpected drift. (should result in an update of the resource if applicable)

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
