### PR TITLE
test(e2e): provision SonarQube for integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,18 @@ Before opening a pull request, run `make reviewable`. If your change affects beh
 
 ## E2E Testing Flow
 
-The integration flow is driven by `make test-integration` or `make e2e.run`. It creates a kind cluster, applies the provider CRDs, and runs `cluster/local/integration_tests.sh`.
+The integration flow is driven by `make test-integration` or `make e2e.run`. It creates a kind cluster, installs Crossplane and the provider, then bootstraps an in-cluster SonarQube instance via `cluster/local/sonarqube_setup.sh` (Deployment + Service in the `default` namespace, plus a `Secret` and a `ClusterProviderConfig` named `e2e` wired to it). Provider pods reach SonarQube at `http://sonarqube.default.svc.cluster.local:9000/api`.
+
+While the integration script is running you can inspect the in-cluster instance with:
+
+```shell
+kubectl logs deployment/sonarqube
+kubectl port-forward svc/sonarqube 9000:9000   # then browse http://localhost:9000
+```
+
+The setup script is idempotent and can be re-run against a live cluster. Cluster teardown (driven by the script's exit trap) destroys the SonarQube Pod along with everything else.
+
+For ad-hoc local exploration outside KIND, the standalone `make sonarqube.start` / `make sonarqube.stop` targets bring up SonarQube directly on the host via Docker or Podman.
 
 For controller development, `make dev` starts a local kind cluster and runs the provider against it. Use `make dev-clean` to remove that cluster when you are done.
 

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -173,6 +173,9 @@ echo_step "waiting for provider to be installed"
 
 kubectl wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=180s
 
+echo_step "configuring in-cluster SonarQube and ClusterProviderConfig"
+KUBECTL="${KUBECTL}" "${projectdir}/cluster/local/sonarqube_setup.sh"
+
 echo_step "uninstalling ${PROJECT_NAME}"
 
 echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -

--- a/cluster/local/sonarqube.yaml
+++ b/cluster/local/sonarqube.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarqube
+  namespace: default
+  labels:
+    app: sonarqube
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: sonarqube
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sonarqube
+  namespace: default
+  labels:
+    app: sonarqube
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sonarqube
+  template:
+    metadata:
+      labels:
+        app: sonarqube
+    spec:
+      containers:
+        - name: sonarqube
+          image: docker.io/library/sonarqube:community
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9000
+              name: http
+              protocol: TCP
+          env:
+            - name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
+              value: "true"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1536Mi"
+            limits:
+              cpu: "2"
+              memory: "3Gi"
+          startupProbe:
+            httpGet:
+              path: /api/system/status
+              port: 9000
+            failureThreshold: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/system/status
+              port: 9000
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/cluster/local/sonarqube_setup.sh
+++ b/cluster/local/sonarqube_setup.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Idempotent setup for an in-cluster SonarQube instance used by e2e tests.
+#
+# Steps:
+#   1. apply Deployment + Service from sonarqube.yaml
+#   2. wait for the Deployment to become Available
+#   3. open a port-forward and wait for SonarQube to report status=UP
+#   4. set the admin password (tolerates already-changed state)
+#   5. (re)generate a deterministic API token
+#   6. write the token to a Kubernetes Secret
+#   7. apply a ClusterProviderConfig wired to the in-cluster Service
+#
+# Required environment:
+#   KUBECTL (path to kubectl, falls back to "kubectl")
+#
+# Optional environment overrides have sensible defaults below.
+set -euo pipefail
+
+KUBECTL="${KUBECTL:-kubectl}"
+
+SONARQUBE_NAMESPACE="${SONARQUBE_NAMESPACE:-default}"
+SONARQUBE_DEPLOYMENT="${SONARQUBE_DEPLOYMENT:-sonarqube}"
+SONARQUBE_SERVICE="${SONARQUBE_SERVICE:-sonarqube}"
+SONARQUBE_ADMIN_PASSWORD="${SONARQUBE_ADMIN_PASSWORD:-adminPassword123!}"
+SONARQUBE_LOCAL_PORT="${SONARQUBE_LOCAL_PORT:-9000}"
+SONARQUBE_TOKEN_NAME="${SONARQUBE_TOKEN_NAME:-e2e-token}"
+SONARQUBE_SECRET_NAME="${SONARQUBE_SECRET_NAME:-sonarqube-credentials}"
+SONARQUBE_SECRET_KEY="${SONARQUBE_SECRET_KEY:-token}"
+SONARQUBE_PROVIDERCONFIG_NAME="${SONARQUBE_PROVIDERCONFIG_NAME:-e2e}"
+SONARQUBE_READY_ATTEMPTS="${SONARQUBE_READY_ATTEMPTS:-3}"
+SONARQUBE_READY_TIMEOUT_SECS="${SONARQUBE_READY_TIMEOUT_SECS:-300}"
+
+SONARQUBE_BASE_URL_IN_CLUSTER="http://${SONARQUBE_SERVICE}.${SONARQUBE_NAMESPACE}.svc.cluster.local:9000/api"
+SONARQUBE_LOCAL_URL="http://localhost:${SONARQUBE_LOCAL_PORT}"
+
+manifest_dir="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
+
+log() { printf '\n>>> %s\n' "$*"; }
+
+log "Applying SonarQube manifests"
+"${KUBECTL}" apply -f "${manifest_dir}/sonarqube.yaml"
+
+log "Waiting for deployment/${SONARQUBE_DEPLOYMENT} to become Available (timeout 10m)"
+"${KUBECTL}" wait --for=condition=Available \
+    "deployment/${SONARQUBE_DEPLOYMENT}" \
+    --namespace="${SONARQUBE_NAMESPACE}" \
+    --timeout=10m
+
+log "Establishing port-forward localhost:${SONARQUBE_LOCAL_PORT} -> ${SONARQUBE_SERVICE}:9000"
+"${KUBECTL}" port-forward "service/${SONARQUBE_SERVICE}" \
+    "${SONARQUBE_LOCAL_PORT}:9000" \
+    --namespace="${SONARQUBE_NAMESPACE}" \
+    >/dev/null 2>&1 &
+port_forward_pid=$!
+trap 'kill ${port_forward_pid} 2>/dev/null || true' EXIT
+
+# Give the port-forward a moment to bind.
+for _ in $(seq 1 30); do
+    if curl -sf -o /dev/null "${SONARQUBE_LOCAL_URL}/api/system/status"; then
+        break
+    fi
+    sleep 1
+done
+
+log "Waiting for SonarQube to report status=UP"
+ready=false
+for attempt in $(seq 1 "${SONARQUBE_READY_ATTEMPTS}"); do
+    deadline=$((SECONDS + SONARQUBE_READY_TIMEOUT_SECS))
+    while [ "${SECONDS}" -lt "${deadline}" ]; do
+        status_body="$(curl -sf "${SONARQUBE_LOCAL_URL}/api/system/status" 2>/dev/null || true)"
+        if echo "${status_body}" | grep -q '"status":"UP"'; then
+            ready=true
+            break 2
+        fi
+        sleep 5
+    done
+    log "attempt ${attempt} timed out after ${SONARQUBE_READY_TIMEOUT_SECS}s, retrying"
+done
+if [ "${ready}" != "true" ]; then
+    echo "ERROR: SonarQube did not become ready" >&2
+    exit 1
+fi
+
+log "Setting admin password (idempotent)"
+http_status="$(curl -s -o /dev/null -w '%{http_code}' \
+    -u "admin:admin" \
+    -X POST "${SONARQUBE_LOCAL_URL}/api/users/change_password" \
+    --data-urlencode "login=admin" \
+    --data-urlencode "password=${SONARQUBE_ADMIN_PASSWORD}" \
+    --data-urlencode "previousPassword=admin")"
+case "${http_status}" in
+    2*) log "admin password updated" ;;
+    401) log "admin password already updated (default creds rejected)" ;;
+    *) echo "ERROR: unexpected HTTP ${http_status} from change_password" >&2; exit 1 ;;
+esac
+
+auth=(-u "admin:${SONARQUBE_ADMIN_PASSWORD}")
+
+log "Revoking any pre-existing token named '${SONARQUBE_TOKEN_NAME}'"
+curl -s -o /dev/null "${auth[@]}" -X POST \
+    "${SONARQUBE_LOCAL_URL}/api/user_tokens/revoke" \
+    --data-urlencode "name=${SONARQUBE_TOKEN_NAME}" || true
+
+log "Generating token '${SONARQUBE_TOKEN_NAME}'"
+token_response="$(curl -sf "${auth[@]}" -X POST \
+    "${SONARQUBE_LOCAL_URL}/api/user_tokens/generate" \
+    --data-urlencode "name=${SONARQUBE_TOKEN_NAME}")"
+sonar_token="$(printf '%s' "${token_response}" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+if [ -z "${sonar_token}" ]; then
+    echo "ERROR: failed to extract token from response: ${token_response}" >&2
+    exit 1
+fi
+
+log "Writing Secret ${SONARQUBE_NAMESPACE}/${SONARQUBE_SECRET_NAME}"
+"${KUBECTL}" create secret generic "${SONARQUBE_SECRET_NAME}" \
+    --namespace="${SONARQUBE_NAMESPACE}" \
+    --from-literal="${SONARQUBE_SECRET_KEY}=${sonar_token}" \
+    --dry-run=client -o yaml | "${KUBECTL}" apply -f -
+
+log "Applying ClusterProviderConfig '${SONARQUBE_PROVIDERCONFIG_NAME}'"
+"${KUBECTL}" apply -f - <<EOF
+apiVersion: sonarqube.crossplane.io/v1alpha1
+kind: ClusterProviderConfig
+metadata:
+  name: ${SONARQUBE_PROVIDERCONFIG_NAME}
+spec:
+  baseUrl: ${SONARQUBE_BASE_URL_IN_CLUSTER}
+  token:
+    source: Secret
+    secretRef:
+      namespace: ${SONARQUBE_NAMESPACE}
+      name: ${SONARQUBE_SECRET_NAME}
+      key: ${SONARQUBE_SECRET_KEY}
+EOF
+
+log "SonarQube ready at ${SONARQUBE_BASE_URL_IN_CLUSTER} (token in ${SONARQUBE_NAMESPACE}/${SONARQUBE_SECRET_NAME})"


### PR DESCRIPTION
### Description of your changes

Add cluster/local/sonarqube.yaml (Deployment + Service in defaultnamespace) and cluster/local/sonarqube_setup.sh: An idempotent script that waits for SonarQube to report status=UP, sets the admin password, generates a deterministic API token, materialises it as a Secret, and applies a ClusterProviderConfig wired to the in-cluster Service URL.

Add the setup into cluster/local/integration_tests.sh after the provider becomes healthy (so the ClusterProviderConfig CRD exists), and document the flow in CONTRIBUTING.md.

Closes #64 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.

### How has this code been tested

I have:

- [x] Ran both commands and ensure they work

[contribution process]: https://git.io/fj2m9
