### PR TITLE
test(e2e): add reusable Go framework for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,15 @@ test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM3)
 	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
+# Run the Go e2e suite against an already-provisioned cluster.
+# Expects SONARQUBE_URL and SONARQUBE_TOKEN to be exported by the caller;
+# cluster/local/integration_tests.sh sets these up around its invocation.
+E2E_TEST_TIMEOUT ?= 30m
+e2e.test:
+	@$(INFO) running e2e Go suite (-tags=e2e)
+	@go test -tags=e2e -timeout=$(E2E_TEST_TIMEOUT) ./internal/test/e2e/... || $(FAIL)
+	@$(OK) e2e Go suite passed
+
 # Update the submodules, such as the common build scripts.
 submodules:
 	@git submodule sync
@@ -104,7 +113,7 @@ dev-clean: $(KIND) $(KUBECTL)
 	@$(INFO) Deleting kind cluster
 	@$(KIND) delete cluster --name=$(PROJECT_NAME)-dev
 
-.PHONY: submodules fallthrough test-integration run dev dev-clean
+.PHONY: submodules fallthrough test-integration e2e.run e2e.test run dev dev-clean
 
 # ====================================================================================
 # Special Targets

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -176,6 +176,27 @@ kubectl wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=health
 echo_step "configuring in-cluster SonarQube and ClusterProviderConfig"
 KUBECTL="${KUBECTL}" "${projectdir}/cluster/local/sonarqube_setup.sh"
 
+echo_step "running e2e Go suite"
+e2e_pf_port="${E2E_SONARQUBE_PORT:-9000}"
+"${KUBECTL}" port-forward -n default service/sonarqube "${e2e_pf_port}:9000" >/dev/null 2>&1 &
+e2e_pf_pid=$!
+# Wait for the port-forward to bind.
+for _ in $(seq 1 30); do
+  if curl -sf -o /dev/null "http://localhost:${e2e_pf_port}/api/system/status"; then
+    break
+  fi
+  sleep 1
+done
+e2e_token="$("${KUBECTL}" get secret -n default sonarqube-credentials -o jsonpath='{.data.token}' | base64 -d)"
+e2e_status=0
+SONARQUBE_URL="http://localhost:${e2e_pf_port}/api" \
+SONARQUBE_TOKEN="${e2e_token}" \
+make -C "${projectdir}" e2e.test || e2e_status=$?
+kill "${e2e_pf_pid}" 2>/dev/null || true
+if [ "${e2e_status}" -ne 0 ]; then
+  echo_error "e2e Go suite failed (exit ${e2e_status})"
+fi
+
 echo_step "uninstalling ${PROJECT_NAME}"
 
 echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -

--- a/internal/test/e2e/assert.go
+++ b/internal/test/e2e/assert.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AssertReady fails the test if obj does not currently report Ready=True.
+func AssertReady(t *testing.T, obj Conditioned) {
+	t.Helper()
+	AssertCondition(t, obj, xpv1.TypeReady, corev1.ConditionTrue)
+}
+
+// AssertSynced fails the test if obj does not currently report Synced=True.
+func AssertSynced(t *testing.T, obj Conditioned) {
+	t.Helper()
+	AssertCondition(t, obj, xpv1.TypeSynced, corev1.ConditionTrue)
+}
+
+// AssertCondition fails the test if the named condition is not at the
+// expected status, surfacing the reason and message for fast triage.
+func AssertCondition(t *testing.T, obj Conditioned, ct xpv1.ConditionType, want corev1.ConditionStatus) {
+	t.Helper()
+	got := obj.GetCondition(ct)
+	if got.Status != want {
+		t.Errorf("%s condition = %s (reason=%s, message=%q); want %s",
+			ct, got.Status, got.Reason, got.Message, want)
+	}
+}
+
+// AssertExternalName fails the test if obj's crossplane.io/external-name
+// annotation does not equal want.
+func AssertExternalName(t *testing.T, obj client.Object, want string) {
+	t.Helper()
+	if got := meta.GetExternalName(obj); got != want {
+		t.Errorf("external-name = %q, want %q", got, want)
+	}
+}

--- a/internal/test/e2e/doc.go
+++ b/internal/test/e2e/doc.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2e provides reusable helpers for end-to-end tests that exercise
+// the provider against a live SonarQube instance and a real Kubernetes API
+// server.
+//
+// All files in this package carry the `e2e` build tag so they are excluded
+// from regular `go test ./...` runs. To execute the suite use:
+//
+//	go test -tags=e2e ./internal/test/e2e/...
+//
+// or, equivalently, `make e2e.test`. Both invocations expect the following
+// environment variables to be set, which `cluster/local/integration_tests.sh`
+// exports automatically:
+//
+//	KUBECONFIG       — points at a cluster running the provider
+//	SONARQUBE_URL    — base URL of the SonarQube API (e.g. http://localhost:9000/api)
+//	SONARQUBE_TOKEN  — admin-scoped SonarQube token used to verify state
+//
+// The companion ClusterProviderConfig used by the managed resources under
+// test is named `e2e` and is created by `cluster/local/sonarqube_setup.sh`.
+package e2e

--- a/internal/test/e2e/example_test.go
+++ b/internal/test/e2e/example_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package e2e_test
+
+import (
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestFrameworkExample is the living documentation for package e2e: it
+// drives a Group resource through the create → ready → verify-in-SonarQube
+// → cleanup flow using only the framework's public surface.
+func TestFrameworkExample(t *testing.T) {
+	f := e2e.New(t)
+
+	const groupName = "e2e-framework-example"
+
+	group := &iamv1alpha1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      groupName,
+			Namespace: "default",
+		},
+		Spec: iamv1alpha1.GroupSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: iamv1alpha1.GroupParameters{
+				Name: groupName,
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, group, 2*time.Minute)
+	e2e.AssertReady(t, group)
+	e2e.AssertSynced(t, group)
+
+	// The provider stores the SonarQube-assigned ID in the external-name
+	// annotation; use it to verify the group really exists in SonarQube.
+	id := group.GetAnnotations()["crossplane.io/external-name"]
+	if id == "" {
+		t.Fatalf("expected external-name annotation to be populated after Ready")
+	}
+	got, err := f.FetchGroup(id)
+	if err != nil {
+		t.Fatalf("fetching group from SonarQube: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("group %s (id=%s) not found in SonarQube", groupName, id)
+	}
+	if got.Name != groupName {
+		t.Errorf("SonarQube group name = %q, want %q", got.Name, groupName)
+	}
+}

--- a/internal/test/e2e/framework.go
+++ b/internal/test/e2e/framework.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/crossplane/provider-sonarqube/apis"
+	"github.com/crossplane/provider-sonarqube/internal/clients/common"
+)
+
+// Environment variable names recognised by the framework.
+const (
+	// EnvSonarQubeURL is the base URL of the SonarQube API used for verification.
+	EnvSonarQubeURL = "SONARQUBE_URL"
+	// EnvSonarQubeToken is an admin-scoped token used by the framework's Sonar client.
+	EnvSonarQubeToken = "SONARQUBE_TOKEN"
+	// EnvProviderConfig is the ClusterProviderConfig name that managed resources should reference.
+	EnvProviderConfig = "SONARQUBE_PROVIDERCONFIG"
+)
+
+// DefaultProviderConfigName is used when EnvProviderConfig is unset; it matches
+// the ClusterProviderConfig provisioned by cluster/local/sonarqube_setup.sh.
+const DefaultProviderConfigName = "e2e"
+
+// Framework groups the clients every e2e test needs: a controller-runtime
+// client wired to the project's schemes, and a SonarQube SDK client
+// authenticated with an admin token. Construct one per test with New.
+type Framework struct {
+	// Kube is a controller-runtime client with the provider's APIs registered.
+	Kube client.Client
+	// Sonar talks to the SonarQube REST API directly, used to verify the
+	// state the provider reconciled into SonarQube.
+	Sonar *sonar.Client
+	// ProviderConfigName is the ClusterProviderConfig managed resources should reference.
+	ProviderConfigName string
+}
+
+// New constructs a Framework, failing the test immediately on missing config
+// or unreachable cluster — there is no value in deferring those errors.
+func New(t *testing.T) *Framework {
+	t.Helper()
+
+	url := mustEnv(t, EnvSonarQubeURL)
+	token := mustEnv(t, EnvSonarQubeToken)
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		t.Fatalf("loading kubeconfig: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("registering core scheme: %v", err)
+	}
+	if err := apis.AddToScheme(scheme); err != nil {
+		t.Fatalf("registering provider schemes: %v", err)
+	}
+
+	kc, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("building kube client: %v", err)
+	}
+
+	sc := common.NewClient(common.Config{
+		AuthType: common.PersonalAccessToken,
+		Token:    token,
+		BaseURL:  url,
+	})
+
+	pc := os.Getenv(EnvProviderConfig)
+	if pc == "" {
+		pc = DefaultProviderConfigName
+	}
+
+	return &Framework{
+		Kube:               kc,
+		Sonar:              sc,
+		ProviderConfigName: pc,
+	}
+}
+
+func mustEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Fatalf("required environment variable %s is not set", key)
+	}
+	return v
+}

--- a/internal/test/e2e/lifecycle.go
+++ b/internal/test/e2e/lifecycle.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DefaultDeleteTimeout bounds how long Cleanup waits for the controller
+// to finalize a managed resource before logging the failure and moving on.
+const DefaultDeleteTimeout = 2 * time.Minute
+
+// Apply creates obj on the cluster, failing the test on any error.
+// Callers that also want automatic cleanup + readiness wait should use
+// CreateAndWaitForReady instead.
+func (f *Framework) Apply(t *testing.T, obj client.Object) {
+	t.Helper()
+	if err := f.Kube.Create(context.Background(), obj); err != nil {
+		t.Fatalf("creating %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+	}
+}
+
+// Update sends a full update of obj, failing the test on any error.
+// The object's resourceVersion must already be populated (call Get or
+// re-fetch the object first).
+func (f *Framework) Update(t *testing.T, obj client.Object) {
+	t.Helper()
+	if err := f.Kube.Update(context.Background(), obj); err != nil {
+		t.Fatalf("updating %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+	}
+}
+
+// Delete removes obj from the cluster, tolerating NotFound so callers can
+// safely invoke this after a previous cleanup.
+func (f *Framework) Delete(t *testing.T, obj client.Object) {
+	t.Helper()
+	if err := f.Kube.Delete(context.Background(), obj); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("deleting %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+	}
+}
+
+// CreateAndWaitForReady creates obj, registers a t.Cleanup that deletes it
+// and waits for the controller to drop the finalizer, then blocks until
+// obj reports Ready+Synced.
+//
+// On a failed wait the test is marked Fatal but cleanup still runs so the
+// next test starts from a clean slate.
+func (f *Framework) CreateAndWaitForReady(t *testing.T, obj Conditioned, timeout time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := f.Kube.Create(ctx, obj); err != nil {
+		t.Fatalf("creating %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+	}
+	t.Cleanup(func() { f.cleanup(t, obj) })
+
+	if err := f.WaitForReady(ctx, obj, timeout); err != nil {
+		t.Fatalf("waiting for %s/%s to be Ready: %v\n  conditions: %s",
+			obj.GetNamespace(), obj.GetName(), err, SummariseConditions(obj))
+	}
+}
+
+// cleanup deletes obj and waits for the API server to confirm its removal.
+// Failures are logged rather than failing the test — by the time cleanup
+// runs the assertions of interest have already happened.
+func (f *Framework) cleanup(t *testing.T, obj client.Object) {
+	ctx := context.Background()
+	if err := f.Kube.Delete(ctx, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		t.Logf("cleanup: deleting %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+		return
+	}
+	if err := f.WaitForDeletion(ctx, obj, DefaultDeleteTimeout); err != nil {
+		t.Logf("cleanup: waiting for deletion of %s/%s: %v",
+			obj.GetNamespace(), obj.GetName(), err)
+	}
+}

--- a/internal/test/e2e/sonarqube.go
+++ b/internal/test/e2e/sonarqube.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package e2e
+
+import (
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+
+	"github.com/crossplane/provider-sonarqube/internal/clients/common"
+	"github.com/crossplane/provider-sonarqube/internal/helpers"
+)
+
+// FetchGroup returns the SonarQube group with the given ID, or (nil, nil)
+// if no such group exists. Use the resource's external-name annotation —
+// the provider stores the SonarQube-assigned ID there — as the lookup key.
+func (f *Framework) FetchGroup(id string) (*sonar.Group, error) {
+	g, resp, err := f.Sonar.V2.Authorizations.FetchGroup(id)
+	defer helpers.CloseBody(resp)
+	if common.IsResponseNotFound(resp) {
+		return nil, nil //nolint:nilnil // intentional: 404 is the natural absence sentinel
+	}
+	if err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// FindGroupByName returns the unique SonarQube group whose name exactly
+// matches name, or (nil, nil) if no such group exists. Useful when the
+// resource's external-name has not been observed yet (e.g. during creation
+// failures), since SonarQube exposes search by name but Fetch requires ID.
+func (f *Framework) FindGroupByName(name string) (*sonar.Group, error) {
+	res, resp, err := f.Sonar.V2.Authorizations.SearchGroups(&sonar.AuthorizationsSearchGroupsOptions{Query: name})
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Groups {
+		if res.Groups[i].Name == name {
+			return &res.Groups[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional: no match is not an error condition for assertions
+}

--- a/internal/test/e2e/wait.go
+++ b/internal/test/e2e/wait.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// pollInterval is how often the wait helpers poll the API server. Two
+// seconds keeps overhead negligible while still feeling responsive.
+const pollInterval = 2 * time.Second
+
+// Conditioned is the slim contract every Crossplane managed resource
+// already satisfies — a Kubernetes object whose status exposes the
+// standard Crossplane condition set.
+type Conditioned interface {
+	client.Object
+	GetCondition(ct xpv1.ConditionType) xpv1.Condition
+}
+
+// WaitForReady polls until obj reports both Synced=True and Ready=True.
+// The supplied object is updated in-place with the latest observed state,
+// so callers may inspect it directly after the call returns.
+func (f *Framework) WaitForReady(ctx context.Context, obj Conditioned, timeout time.Duration) error {
+	key := client.ObjectKeyFromObject(obj)
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := f.Kube.Get(ctx, key, obj); err != nil {
+			return false, err
+		}
+		synced := obj.GetCondition(xpv1.TypeSynced)
+		ready := obj.GetCondition(xpv1.TypeReady)
+		return synced.Status == corev1.ConditionTrue && ready.Status == corev1.ConditionTrue, nil
+	})
+}
+
+// WaitForDeletion polls until obj is no longer present in the API server.
+// A nil error means the resource was confirmed deleted within the timeout.
+func (f *Framework) WaitForDeletion(ctx context.Context, obj client.Object, timeout time.Duration) error {
+	key := client.ObjectKeyFromObject(obj)
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		err := f.Kube.Get(ctx, key, obj)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+}
+
+// SummariseConditions renders a one-line diagnostic of the standard
+// Crossplane conditions, suitable for inclusion in a t.Fatalf message.
+func SummariseConditions(obj Conditioned) string {
+	synced := obj.GetCondition(xpv1.TypeSynced)
+	ready := obj.GetCondition(xpv1.TypeReady)
+	return fmt.Sprintf("Synced=%s(%s: %q) Ready=%s(%s: %q)",
+		synced.Status, synced.Reason, synced.Message,
+		ready.Status, ready.Reason, ready.Message,
+	)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds internal/test/e2e, a //go:build e2e Go package that wraps the controller-runtime client and the SonarQube SDK behind helpers intended to keep per-resource test files short and consistent:

- Framework.New(t) reads SONARQUBE_URL / SONARQUBE_TOKEN / SONARQUBE_PROVIDERCONFIG and constructs both clients.
- WaitForReady / WaitForDeletion poll the standard Crossplane conditions; CreateAndWaitForReady registers a t.Cleanup that deletes the resource and waits for finalizer drop.
- Assert{Ready,Synced,Condition,ExternalName} fail the test with reason+message diagnostics.
- FetchGroup / FindGroupByName wrap the SonarQube SDK and surface 404s as nil so assertions read naturally.
- example_test.go drives the create -> ready -> verify-via-SDK -> cleanup flow against a Group resource as living documentation.

Create a `make e2e.test` target and have integration_tests.sh port-forward SonarQube, export the token from the in-cluster Secret, and invoke the suite; the integration script fails when the Go suite fails.

Closes #65 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have:

- [x] ran and tested the new makefile command

[contribution process]: https://git.io/fj2m9
