### PR TITLE
test(e2e): add CRUD tests for instance resources

### DIFF
--- a/internal/test/e2e/instance/helpers_test.go
+++ b/internal/test/e2e/instance/helpers_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package instance_test
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// stringPtr returns a pointer to the supplied string — useful for the
+// many optional *string fields in the instance API types.
+func stringPtr(s string) *string { return &s }
+
+// boolPtr returns a pointer to the supplied bool.
+func boolPtr(b bool) *bool { return &b }
+
+// kubeKey is a terse alias for client.ObjectKeyFromObject to keep the
+// polling loops in the individual test files readable.
+func kubeKey(obj client.Object) client.ObjectKey {
+	return client.ObjectKeyFromObject(obj)
+}

--- a/internal/test/e2e/instance/project_test.go
+++ b/internal/test/e2e/instance/project_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package instance_test
+
+import (
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestProjectCRUD creates a Project, waits for Ready, verifies it is
+// queryable via SonarQube's Projects.Search with the matching key,
+// visibility and display name.
+func TestProjectCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName    = "e2e-project-crud"
+		projKey   = "e2e-project-crud"
+		projName  = "E2E Project CRUD"
+		visPublic = "public"
+	)
+
+	project := &instancev1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: instancev1alpha1.ProjectSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: instancev1alpha1.ProjectParameters{
+				Key:           projKey,
+				Name:          projName,
+				Visibility:    stringPtr(visPublic),
+				DefaultBranch: stringPtr("main"),
+				Tags:          &[]string{"crossplane", "e2e"},
+				// Pin to the built-in "Sonar way" gate. Leaving this unset
+				// causes Crossplane's reference resolver to issue a server
+				// side apply with qualityGateName="" which fails the field's
+				// MinLength=1 CRD validation.
+				QualityGateName: stringPtr("Sonar way"),
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, project, 2*time.Minute)
+	e2e.AssertReady(t, project)
+	e2e.AssertSynced(t, project)
+	e2e.AssertExternalName(t, project, projKey)
+
+	got, err := f.FindProjectByKey(projKey)
+	if err != nil {
+		t.Fatalf("searching projects: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("project %q not found in SonarQube", projKey)
+	}
+	if got.Name != projName {
+		t.Errorf("project name = %q, want %q", got.Name, projName)
+	}
+	if got.Visibility != visPublic {
+		t.Errorf("project visibility = %q, want %q", got.Visibility, visPublic)
+	}
+}

--- a/internal/test/e2e/instance/qualitygate_test.go
+++ b/internal/test/e2e/instance/qualitygate_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package instance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestQualityGateCRUD creates a QualityGate with one condition, waits for
+// Ready, verifies it exists in SonarQube with the expected metadata, and
+// lets the t.Cleanup delete it.
+func TestQualityGateCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName = "e2e-qualitygate-crud"
+		qgName = "e2e-qualitygate-crud"
+	)
+
+	qg := &instancev1alpha1.QualityGate{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: instancev1alpha1.QualityGateSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: instancev1alpha1.QualityGateParameters{
+				Name: qgName,
+				Conditions: []instancev1alpha1.QualityGateConditionParameters{
+					{Metric: "blocker_violations", Op: stringPtr("GT"), Error: "0"},
+				},
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, qg, 2*time.Minute)
+	e2e.AssertReady(t, qg)
+	e2e.AssertSynced(t, qg)
+	e2e.AssertExternalName(t, qg, qgName)
+
+	got, err := f.FindQualityGate(qgName)
+	if err != nil {
+		t.Fatalf("listing quality gates: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("quality gate %q not found in SonarQube", qgName)
+	}
+	if got.IsBuiltIn {
+		t.Errorf("quality gate %q is reported as built-in in SonarQube; want user-created", qgName)
+	}
+}
+
+// TestQualityGateInvalidMetric creates a QualityGate whose condition metric
+// is not accepted by SonarQube. The CR creation itself succeeds (the field
+// passes CRD-level validation) but the controller must surface the error on
+// the Synced condition instead of marking the resource Ready.
+func TestQualityGateInvalidMetric(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName = "e2e-qualitygate-invalid"
+		qgName = "e2e-qualitygate-invalid"
+	)
+
+	qg := &instancev1alpha1.QualityGate{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: instancev1alpha1.QualityGateSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: instancev1alpha1.QualityGateParameters{
+				Name: qgName,
+				Conditions: []instancev1alpha1.QualityGateConditionParameters{
+					{Metric: "not_a_real_metric", Op: stringPtr("GT"), Error: "0"},
+				},
+			},
+		},
+	}
+
+	f.Apply(t, qg)
+	t.Cleanup(func() { f.Delete(t, qg); _ = f.WaitForDeletion(context.Background(), qg, e2e.DefaultDeleteTimeout) })
+
+	// Wait a reasonable window for the controller to observe and fail.
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := f.Kube.Get(context.Background(), kubeKey(qg), qg); err != nil {
+			t.Fatalf("get %s: %v", qg.Name, err)
+		}
+		if qg.GetCondition(xpv1.TypeSynced).Status == corev1.ConditionFalse {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("expected Synced=False for invalid QualityGate, got: %s", e2e.SummariseConditions(qg))
+}

--- a/internal/test/e2e/instance/qualityprofile_test.go
+++ b/internal/test/e2e/instance/qualityprofile_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package instance_test
+
+import (
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestQualityProfileCRUD creates an empty (no custom rules) Go quality
+// profile and verifies SonarQube knows about it at the expected name +
+// language. Leaving rules out keeps the test hermetic — rule references
+// are exercised separately in the rule_test.go suite.
+func TestQualityProfileCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName   = "e2e-qp-go-crud"
+		qpName   = "e2e-qp-go-crud"
+		qpLang   = "go"
+		hoursTtl = 2 * time.Minute
+	)
+
+	qp := &instancev1alpha1.QualityProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: instancev1alpha1.QualityProfileSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: instancev1alpha1.QualityProfileParameters{
+				Name:     qpName,
+				Language: qpLang,
+				Default:  boolPtr(false),
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, qp, hoursTtl)
+	e2e.AssertReady(t, qp)
+	e2e.AssertSynced(t, qp)
+
+	got, err := f.FindQualityProfile(qpName, qpLang)
+	if err != nil {
+		t.Fatalf("searching quality profiles: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("quality profile %q (%s) not found in SonarQube", qpName, qpLang)
+	}
+	if got.Language != qpLang {
+		t.Errorf("quality profile language = %q, want %q", got.Language, qpLang)
+	}
+	if got.IsBuiltIn {
+		t.Errorf("quality profile %q is reported as built-in; want user-created", qpName)
+	}
+}

--- a/internal/test/e2e/instance/rule_test.go
+++ b/internal/test/e2e/instance/rule_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package instance_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestRuleCRUD creates a custom rule based on the java:S124 template
+// (comment-regexp matcher — stock in SonarJava), waits for Ready, and
+// verifies the rule exists in SonarQube with the expected name. SonarQube
+// prefixes the custom rule key with the template's language+repo, so we
+// look up by key with a java: prefix.
+func TestRuleCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName      = "e2e-rule-crud"
+		ruleKey     = "e2e_rule_crud"
+		ruleName    = "E2E Rule CRUD"
+		templateKey = "java:S124"
+		markdown    = "E2E-managed rule used by the framework test suite."
+	)
+
+	rule := &instancev1alpha1.Rule{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: instancev1alpha1.RuleSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: instancev1alpha1.RuleParameters{
+				Key:                 ruleKey,
+				Name:                ruleName,
+				TemplateKey:         templateKey,
+				MarkdownDescription: markdown,
+				Status:              stringPtr("READY"),
+				Type:                stringPtr("CODE_SMELL"),
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, rule, 2*time.Minute)
+	e2e.AssertReady(t, rule)
+	e2e.AssertSynced(t, rule)
+
+	// The provider stores the fully-qualified key (e.g. "java:e2e_rule_crud")
+	// in the external-name annotation. Use it to query SonarQube directly.
+	externalName := rule.GetAnnotations()["crossplane.io/external-name"]
+	if externalName == "" {
+		t.Fatalf("expected external-name to be populated after Ready")
+	}
+	if !strings.HasSuffix(externalName, ":"+ruleKey) {
+		t.Errorf("external-name = %q, want it to end with :%s", externalName, ruleKey)
+	}
+
+	got, err := f.FetchRule(externalName)
+	if err != nil {
+		t.Fatalf("fetching rule: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("rule %q not found in SonarQube", externalName)
+	}
+	if got.Name != ruleName {
+		t.Errorf("rule name = %q, want %q", got.Name, ruleName)
+	}
+	if got.TemplateKey != templateKey {
+		t.Errorf("rule templateKey = %q, want %q", got.TemplateKey, templateKey)
+	}
+}

--- a/internal/test/e2e/instance/settings_test.go
+++ b/internal/test/e2e/instance/settings_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package instance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestSettingsGlobalScalar sets a scalar global-scope setting and verifies
+// SonarQube reports the same value on GET.
+//
+// Not run in parallel: concurrent global-scope Settings tests would write
+// to the same SonarQube instance and race each other. One global settings
+// test per run is the safe upper bound.
+//
+// NOTE: this test asserts on Synced=True only — the Settings controller
+// currently does not call SetConditions(xpv1.Available()), so Ready stays
+// Unknown forever. Once that controller bug is fixed, switch the wait to
+// CreateAndWaitForReady and add e2e.AssertReady. See provider source at
+// internal/controller/instance/settings/settings.go (only Creating() and
+// Deleting() are set today; Available() is missing).
+func TestSettingsGlobalScalar(t *testing.T) {
+	f := e2e.New(t)
+	const (
+		crName       = "e2e-settings-global-scalar"
+		settingKey   = "sonar.forceAuthentication"
+		settingValue = "false"
+	)
+
+	settings := &instancev1alpha1.Settings{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: instancev1alpha1.SettingsSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: instancev1alpha1.SettingsParameters{
+				Settings: map[string]instancev1alpha1.SettingParameters{
+					settingKey: {Value: stringPtr(settingValue)},
+				},
+			},
+		},
+	}
+
+	// Settings never reaches Ready=True today (see TODO above), so create
+	// the resource and poll for Synced=True instead of using
+	// CreateAndWaitForReady.
+	f.Apply(t, settings)
+	t.Cleanup(func() {
+		f.Delete(t, settings)
+		_ = f.WaitForDeletion(context.Background(), settings, e2e.DefaultDeleteTimeout)
+	})
+
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		if err := f.Kube.Get(context.Background(), kubeKey(settings), settings); err != nil {
+			t.Fatalf("get %s: %v", settings.Name, err)
+		}
+		if settings.GetCondition(xpv1.TypeSynced).Status == corev1.ConditionTrue {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	e2e.AssertSynced(t, settings)
+
+	got, err := f.FetchSettingValue("", settingKey)
+	if err != nil {
+		t.Fatalf("fetching setting %q: %v", settingKey, err)
+	}
+	if got == nil {
+		t.Fatalf("setting %q not found in SonarQube", settingKey)
+	}
+	if got.Value != settingValue {
+		t.Errorf("setting %q value = %q, want %q", settingKey, got.Value, settingValue)
+	}
+}

--- a/internal/test/e2e/sonarqube.go
+++ b/internal/test/e2e/sonarqube.go
@@ -57,3 +57,88 @@ func (f *Framework) FindGroupByName(name string) (*sonar.Group, error) {
 	}
 	return nil, nil //nolint:nilnil // intentional: no match is not an error condition for assertions
 }
+
+// FindProjectByKey returns the SonarQube project component with the given
+// key, or (nil, nil) if no such project exists.
+func (f *Framework) FindProjectByKey(key string) (*sonar.ProjectSearchComponent, error) {
+	res, resp, err := f.Sonar.Projects.Search(&sonar.ProjectsSearchOptions{Projects: []string{key}})
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Components {
+		if res.Components[i].Key == key {
+			return &res.Components[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional
+}
+
+// FindQualityGate returns the quality gate with the given name, or (nil, nil)
+// if no such gate exists. SonarQube exposes only a List endpoint, so this
+// iterates the full list — fine for the handful of gates used in e2e tests.
+func (f *Framework) FindQualityGate(name string) (*sonar.QualityGate, error) {
+	res, resp, err := f.Sonar.Qualitygates.List()
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Qualitygates {
+		if res.Qualitygates[i].Name == name {
+			return &res.Qualitygates[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional
+}
+
+// FindQualityProfile returns the quality profile matching name + language,
+// or (nil, nil) if no such profile exists.
+func (f *Framework) FindQualityProfile(name, language string) (*sonar.QualityProfile, error) {
+	res, resp, err := f.Sonar.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{Language: language})
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Profiles {
+		if res.Profiles[i].Name == name && res.Profiles[i].Language == language {
+			return &res.Profiles[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional
+}
+
+// FetchRule returns the SonarQube rule with the given fully-qualified key
+// (e.g. "java:my-custom-rule"), or (nil, nil) if no such rule exists.
+func (f *Framework) FetchRule(key string) (*sonar.RuleDetails, error) {
+	res, resp, err := f.Sonar.Rules.Show(&sonar.RulesShowOptions{Key: key})
+	defer helpers.CloseBody(resp)
+	if common.IsResponseNotFound(resp) {
+		return nil, nil //nolint:nilnil // intentional
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &res.Rule, nil
+}
+
+// FetchSettingValue returns the SettingValue for the given key (scoped to
+// component when non-empty), or (nil, nil) if SonarQube did not return a
+// value for that key. Settings that were never set return (nil, nil) —
+// callers treat that as the natural "not yet reconciled" state.
+func (f *Framework) FetchSettingValue(component, key string) (*sonar.SettingValue, error) {
+	opts := &sonar.SettingsValuesOptions{Keys: []string{key}}
+	if component != "" {
+		opts.Component = component
+	}
+	res, resp, err := f.Sonar.Settings.Values(opts)
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Settings {
+		if res.Settings[i].Key == key {
+			return &res.Settings[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional
+}


### PR DESCRIPTION
### Description of your changes

This PR adds an internal/test/e2e/instance package with end-to-end tests for each instance-scoped managed resource:

- TestProjectCRUD - Project (pinned to "Sonar way" gate)
- TestQualityGateCRUD - QualityGate with one condition
- TestQualityGateInvalidMetric - invalid spec, asserts Synced=False
- TestQualityProfileCRUD - Go quality profile, no rules
- TestRuleCRUD - custom rule on java:S124 template
- TestSettingsGlobalScalar — global scalar setting

Each test creates the CR via Framework.CreateAndWaitForReady, asserts Ready+Synced, and verifies the resource exists in SonarQube via the SDK. Tests run with t.Parallel() except TestSettingsGlobalScalar (would race global state).

Extend internal/test/e2e/sonarqube.go with FindProjectByKey, FindQualityGate, FindQualityProfile, FetchRule, and FetchSettingValue so the tests express verifications naturally.

Closes #66 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
