### PR TITLE
test(e2e): add CRUD tests for IAM resources

### DIFF
--- a/internal/controller/instance/settings/settings.go
+++ b/internal/controller/instance/settings/settings.go
@@ -178,6 +178,8 @@ func (c *external) Observe(ctx context.Context, managedResource resource.Managed
 	observation := instance.GenerateSettingsObservation(sonarSettings)
 	settings.Status.AtProvider = observation
 
+	settings.SetConditions(xpv1.Available())
+
 	return managed.ExternalObservation{
 		ResourceExists:   true,
 		ResourceUpToDate: instance.AreSettingsUpToDate(settings.Spec.ForProvider, observation),

--- a/internal/test/e2e/iam/group_test.go
+++ b/internal/test/e2e/iam/group_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package iam_test
+
+import (
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestGroupCRUD creates a Group with two permissions, waits for Ready,
+// verifies the SonarQube group exists with the expected name and that the
+// global permissions API reports the requested set.
+func TestGroupCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName    = "e2e-group-crud"
+		groupName = "e2e-group-crud"
+	)
+	wantPerms := []string{"scan", "provisioning"}
+
+	group := &iamv1alpha1.Group{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: iamv1alpha1.GroupSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: iamv1alpha1.GroupParameters{
+				Name:        groupName,
+				Description: stringPtr("E2E-managed group"),
+				Permissions: &wantPerms,
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, group, 2*time.Minute)
+	e2e.AssertReady(t, group)
+	e2e.AssertSynced(t, group)
+
+	// External-name annotation holds the SonarQube group ID.
+	id := group.GetAnnotations()["crossplane.io/external-name"]
+	if id == "" {
+		t.Fatalf("expected external-name to be populated after Ready")
+	}
+
+	got, err := f.FetchGroup(id)
+	if err != nil {
+		t.Fatalf("fetching group: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("group %q (id=%s) not found in SonarQube", groupName, id)
+	}
+	if got.Name != groupName {
+		t.Errorf("group name = %q, want %q", got.Name, groupName)
+	}
+
+	gotPerms, err := f.GroupPermissions(groupName)
+	if err != nil {
+		t.Fatalf("fetching group permissions: %v", err)
+	}
+	if !equalStringSets(gotPerms, wantPerms) {
+		t.Errorf("group permissions = %v, want %v (order ignored)", gotPerms, wantPerms)
+	}
+}

--- a/internal/test/e2e/iam/helpers_test.go
+++ b/internal/test/e2e/iam/helpers_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package iam_test
+
+import (
+	"sort"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// stringPtr returns a pointer to the supplied string.
+func stringPtr(s string) *string { return &s }
+
+// boolPtr returns a pointer to the supplied bool.
+func boolPtr(b bool) *bool { return &b }
+
+// kubeKey is a terse alias for client.ObjectKeyFromObject.
+func kubeKey(obj client.Object) client.ObjectKey {
+	return client.ObjectKeyFromObject(obj)
+}
+
+// equalStringSets returns true if a and b contain the same elements
+// regardless of order.
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/test/e2e/iam/permissionstemplate_test.go
+++ b/internal/test/e2e/iam/permissionstemplate_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package iam_test
+
+import (
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestPermissionsTemplateCRUD creates a PermissionsTemplate with a
+// project-key pattern and verifies SonarQube reports it via SearchTemplates.
+func TestPermissionsTemplateCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName       = "e2e-permstemplate-crud"
+		templateName = "e2e-permstemplate-crud"
+		keyPattern   = "^e2e-permstemplate-.*"
+	)
+
+	pt := &iamv1alpha1.PermissionsTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: iamv1alpha1.PermissionsTemplateSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: iamv1alpha1.PermissionsTemplateParameters{
+				Name:              templateName,
+				Description:       stringPtr("E2E-managed permissions template"),
+				ProjectKeyPattern: stringPtr(keyPattern),
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, pt, 2*time.Minute)
+	e2e.AssertReady(t, pt)
+	e2e.AssertSynced(t, pt)
+
+	got, err := f.FindPermissionsTemplate(templateName)
+	if err != nil {
+		t.Fatalf("searching permissions templates: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("permissions template %q not found in SonarQube", templateName)
+	}
+	if got.ProjectKeyPattern != keyPattern {
+		t.Errorf("template projectKeyPattern = %q, want %q", got.ProjectKeyPattern, keyPattern)
+	}
+}

--- a/internal/test/e2e/iam/user_test.go
+++ b/internal/test/e2e/iam/user_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package iam_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestUserCRUD provisions a password Secret, then creates a local User
+// referencing it. Waits for Ready and verifies the user exists in
+// SonarQube with the expected login, name and email.
+func TestUserCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName     = "e2e-user-crud"
+		userLogin  = "e2e-user-crud"
+		userName   = "E2E User CRUD"
+		userEmail  = "e2e-user-crud@example.com"
+		secretName = "e2e-user-crud-password"
+		secretKey  = "password"
+	)
+
+	pwSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{secretKey: "e2e-password-123!"},
+	}
+	if err := f.Kube.Create(context.Background(), pwSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating password secret: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = f.Kube.Delete(context.Background(), pwSecret)
+	})
+
+	user := &iamv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: iamv1alpha1.UserSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: iamv1alpha1.UserParameters{
+				Login: userLogin,
+				Name:  userName,
+				Email: stringPtr(userEmail),
+				Local: boolPtr(true),
+				PasswordSecretRef: &xpv1.SecretKeySelector{
+					Key: secretKey,
+					SecretReference: xpv1.SecretReference{
+						Name:      secretName,
+						Namespace: "default",
+					},
+				},
+				// Anonymise on delete so re-creating with the same login
+				// after a previous run leaves no observable trace.
+				Anonymize: boolPtr(true),
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, user, 2*time.Minute)
+	e2e.AssertReady(t, user)
+	e2e.AssertSynced(t, user)
+
+	id := user.GetAnnotations()["crossplane.io/external-name"]
+	if id == "" {
+		t.Fatalf("expected external-name to be populated after Ready")
+	}
+
+	got, err := f.FetchUser(id)
+	if err != nil {
+		t.Fatalf("fetching user: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("user %q (id=%s) not found in SonarQube", userLogin, id)
+	}
+	if got.Login != userLogin {
+		t.Errorf("user login = %q, want %q", got.Login, userLogin)
+	}
+	if got.Name != userName {
+		t.Errorf("user name = %q, want %q", got.Name, userName)
+	}
+	if got.Email != userEmail {
+		t.Errorf("user email = %q, want %q", got.Email, userEmail)
+	}
+	if !got.Local {
+		t.Errorf("user local = false, want true")
+	}
+}

--- a/internal/test/e2e/instance/settings_test.go
+++ b/internal/test/e2e/instance/settings_test.go
@@ -19,13 +19,11 @@ limitations under the License.
 package instance_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
@@ -38,13 +36,6 @@ import (
 // Not run in parallel: concurrent global-scope Settings tests would write
 // to the same SonarQube instance and race each other. One global settings
 // test per run is the safe upper bound.
-//
-// NOTE: this test asserts on Synced=True only — the Settings controller
-// currently does not call SetConditions(xpv1.Available()), so Ready stays
-// Unknown forever. Once that controller bug is fixed, switch the wait to
-// CreateAndWaitForReady and add e2e.AssertReady. See provider source at
-// internal/controller/instance/settings/settings.go (only Creating() and
-// Deleting() are set today; Available() is missing).
 func TestSettingsGlobalScalar(t *testing.T) {
 	f := e2e.New(t)
 	const (
@@ -70,25 +61,8 @@ func TestSettingsGlobalScalar(t *testing.T) {
 		},
 	}
 
-	// Settings never reaches Ready=True today (see TODO above), so create
-	// the resource and poll for Synced=True instead of using
-	// CreateAndWaitForReady.
-	f.Apply(t, settings)
-	t.Cleanup(func() {
-		f.Delete(t, settings)
-		_ = f.WaitForDeletion(context.Background(), settings, e2e.DefaultDeleteTimeout)
-	})
-
-	deadline := time.Now().Add(2 * time.Minute)
-	for time.Now().Before(deadline) {
-		if err := f.Kube.Get(context.Background(), kubeKey(settings), settings); err != nil {
-			t.Fatalf("get %s: %v", settings.Name, err)
-		}
-		if settings.GetCondition(xpv1.TypeSynced).Status == corev1.ConditionTrue {
-			break
-		}
-		time.Sleep(2 * time.Second)
-	}
+	f.CreateAndWaitForReady(t, settings, 2*time.Minute)
+	e2e.AssertReady(t, settings)
 	e2e.AssertSynced(t, settings)
 
 	got, err := f.FetchSettingValue("", settingKey)

--- a/internal/test/e2e/sonarqube.go
+++ b/internal/test/e2e/sonarqube.go
@@ -142,3 +142,55 @@ func (f *Framework) FetchSettingValue(component, key string) (*sonar.SettingValu
 	}
 	return nil, nil //nolint:nilnil // intentional
 }
+
+// FetchUser returns the SonarQube user with the given ID, or (nil, nil)
+// if no such user exists. The provider stores the user ID in the
+// external-name annotation, so the typical lookup is
+// f.FetchUser(meta.GetExternalName(user)).
+func (f *Framework) FetchUser(id string) (*sonar.UserV2, error) {
+	u, resp, err := f.Sonar.V2.UsersManagement.Fetch(id)
+	defer helpers.CloseBody(resp)
+	if common.IsResponseNotFound(resp) {
+		return nil, nil //nolint:nilnil // intentional
+	}
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+// FindPermissionsTemplate returns the permissions template whose name
+// exactly matches name, or (nil, nil) if no such template exists.
+func (f *Framework) FindPermissionsTemplate(name string) (*sonar.PermissionTemplate, error) {
+	res, resp, err := f.Sonar.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{Query: name})
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.PermissionTemplates {
+		if res.PermissionTemplates[i].Name == name {
+			return &res.PermissionTemplates[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional
+}
+
+// GroupPermissions returns the global permissions assigned to the named
+// group. Returns an empty (non-nil) slice when SonarQube knows the group
+// but it has no global permissions, and an error when the group is unknown
+// or the API call fails.
+func (f *Framework) GroupPermissions(groupName string) ([]string, error) {
+	res, resp, err := f.Sonar.Permissions.Groups(&sonar.PermissionsGroupsOptions{Query: groupName})
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Groups {
+		if res.Groups[i].Name == groupName {
+			perms := make([]string, len(res.Groups[i].Permissions))
+			copy(perms, res.Groups[i].Permissions)
+			return perms, nil
+		}
+	}
+	return []string{}, nil
+}


### PR DESCRIPTION
### Description of your changes

This PR adds an internal/test/e2e/iam package with end-to-end tests for each IAM-scoped managed resource:

- TestGroupCRUD - Group with permissions; verifies global permissions assignment via the PermissionsService
- TestPermissionsTemplateCRUD - PermissionsTemplate with project-key pattern (Synced-only, see TODO)
- TestUserCRUD - local User with password Secret; verifies login/name/email/local in SonarQube via UsersManagement.Fetch

Extend internal/test/e2e/sonarqube.go with FetchUser, FindPermissionsTemplate, and GroupPermissions so the iam tests verify against the live SonarQube API directly.

This also fixes a bug in the Settings resource, where the available status was never set, so resource was never set to "Ready"

Closes #67 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
