### PR TITLE
ci: add e2e-tests job to pull-request pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
     needs: [detect-noop, lint, unit-tests]
     if: needs.detect-noop.outputs.noop != 'true'
     timeout-minutes: 30
+    environment: pr-validation
 
     env:
       # Skip the integration script's own kind teardown trap so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,6 @@ jobs:
       - name: Download Go Modules
         run: make modules.download modules.check
 
-      - name: Pre-pull SonarQube image
-        # Pull the (~1.4 GB) SonarQube community image once on the host so
-        # KIND's `kind load docker-image` (run later by sonarqube_setup.sh
-        # via the in-cluster Pod) doesn't re-pull it during the slow path.
-        run: docker pull docker.io/library/sonarqube:community
-
       - name: Build provider artifacts
         run: make build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,100 @@ jobs:
           flags: unittests
           files: _output/tests/linux_amd64/coverage.txt
 
+  e2e-tests:
+    runs-on: ubuntu-24.04
+    needs: [detect-noop, lint, unit-tests]
+    if: needs.detect-noop.outputs.noop != 'true'
+    timeout-minutes: 30
+
+    env:
+      # Skip the integration script's own kind teardown trap so the
+      # collect-diagnostics step can read logs out of the cluster on
+      # failure. The runner is ephemeral, so leaving the cluster running
+      # is harmless; the explicit teardown step below cleans it up.
+      skipcleanup: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "cachedir=$(make go.cachedir)" >> $GITHUB_ENV
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.cachedir }}
+          key: ${{ runner.os }}-build-e2e-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-e2e-tests-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v5
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Download Go Modules
+        run: make modules.download modules.check
+
+      - name: Pre-pull SonarQube image
+        # Pull the (~1.4 GB) SonarQube community image once on the host so
+        # KIND's `kind load docker-image` (run later by sonarqube_setup.sh
+        # via the in-cluster Pod) doesn't re-pull it during the slow path.
+        run: docker pull docker.io/library/sonarqube:community
+
+      - name: Build provider artifacts
+        run: make build
+        env:
+          BUILD_ARGS: "--load"
+
+      - name: Run e2e suite
+        run: make e2e.run
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          mkdir -p _output/e2e-logs
+          for cluster in $(kind get clusters 2>/dev/null); do
+            ctx="kind-$cluster"
+            echo "--- $cluster ---"
+            kubectl --context "$ctx" get all -A > "_output/e2e-logs/${cluster}-get-all.txt" 2>&1
+            kubectl --context "$ctx" describe pods -A > "_output/e2e-logs/${cluster}-describe-pods.txt" 2>&1
+            kubectl --context "$ctx" describe managed > "_output/e2e-logs/${cluster}-describe-managed.txt" 2>&1
+            kubectl --context "$ctx" logs -n default deployment/sonarqube --tail=-1 > "_output/e2e-logs/${cluster}-sonarqube.log" 2>&1
+            kubectl --context "$ctx" logs -n crossplane-system -l pkg.crossplane.io/provider=provider-sonarqube --tail=-1 > "_output/e2e-logs/${cluster}-provider.log" 2>&1
+            kubectl --context "$ctx" logs -n crossplane-system deployment/crossplane --tail=-1 > "_output/e2e-logs/${cluster}-crossplane.log" 2>&1
+          done
+          ls -la _output/e2e-logs/
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-logs
+          path: _output/e2e-logs/
+          if-no-files-found: ignore
+
+      - name: Tear down kind clusters
+        if: always()
+        run: |
+          for cluster in $(kind get clusters 2>/dev/null); do
+            kind delete cluster --name "$cluster" || true
+          done
+
   publish-artifacts:
     runs-on: ubuntu-24.04
     needs: detect-noop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,11 +70,14 @@ For ad-hoc local exploration outside KIND, the standalone `make sonarqube.start`
 
 For controller development, `make dev` starts a local kind cluster and runs the provider against it. Use `make dev-clean` to remove that cluster when you are done.
 
+`make e2e.run` also runs in CI on every pull request (`e2e-tests` job in `.github/workflows/ci.yml`). PRs that change the provider runtime, the integration script, or anything under `internal/test/e2e/` should be exercised locally with `make e2e.run` before pushing — the CI run is ~15 minutes on a warm cache and the local cycle is faster to iterate on.
+
 ## CI
 
-The CI workflow currently runs these high-level checks:
+The CI workflow runs these high-level checks on every pull request:
 
 * linting
 * a diff check to keep generated artifacts in sync
 * unit tests with coverage publication
+* the e2e suite via `make e2e.run` (logs from a failing run are uploaded as the `e2e-logs` artifact)
 * artifact publishing for tagged and branch builds

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ GOLANGCILINT_VERSION = 2.10.1
 # ====================================================================================
 # Setup Kubernetes tools
 
+# Use Helm 3. Without this the k8s_tools machinery defaults to Helm 2 and
+# cluster/local/integration_tests.sh fails on `helm repo add`/`helm install`.
+USE_HELM := true
+
+# Default kindest/node tag. KIND v0.23.0 (the submodule's pinned version)
+# supports kindest/node tags up to v1.30.0. Override via env if needed.
+KIND_NODE_IMAGE_TAG ?= v1.30.0
+
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
@@ -44,6 +52,25 @@ XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane ghcr.io/crossplane-contri
 XPKGS = provider-sonarqube
 -include build/makelib/xpkg.mk
 
+# ====================================================================================
+# Setup Local Development & E2E
+
+# Pin the kind cluster name used by both controlplane.up and
+# local.xpkg.deploy.provider.* so cluster/local/integration_tests.sh and
+# the build submodule agree on which cluster to deploy into. The default
+# in the submodule is "local-dev"; we want a build-id-tagged name so
+# parallel CI runs do not collide.
+KIND_CLUSTER_NAME ?= $(BUILD_REGISTRY)-inttests
+
+# Pin the Crossplane chart version. The submodule's controlplane.up runs
+# `helm install ... --version $(CROSSPLANE_VERSION)`, which fails with
+# "flag needs an argument" when CROSSPLANE_VERSION is empty. Pinning here
+# also keeps e2e runs reproducible.
+CROSSPLANE_VERSION ?= 2.2.1
+
+-include build/makelib/controlplane.mk
+-include build/makelib/local.xpkg.mk
+
 # NOTE(hasheddan): we force image building to happen prior to xpkg build so that
 # we ensure image is present in daemon.
 xpkg.build.provider-sonarqube: do.build.images
@@ -56,9 +83,9 @@ fallthrough: submodules
 e2e.run: test-integration
 
 # Run integration tests.
-test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM3)
+test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
-	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
+	@KIND_NODE_IMAGE_TAG=$(KIND_NODE_IMAGE_TAG) $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
 # Run the Go e2e suite against an already-provisioned cluster.
@@ -66,7 +93,7 @@ test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM3)
 # cluster/local/integration_tests.sh sets these up around its invocation.
 E2E_TEST_TIMEOUT ?= 30m
 e2e.test:
-	@$(INFO) running e2e Go suite (-tags=e2e)
+	@$(INFO) running e2e Go suite with build tag e2e
 	@go test -tags=e2e -timeout=$(E2E_TEST_TIMEOUT) ./internal/test/e2e/... || $(FAIL)
 	@$(OK) e2e Go suite passed
 

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -3,175 +3,107 @@ set -e
 
 # setting up colors
 BLU='\033[0;34m'
-YLW='\033[0;33m'
 GRN='\033[0;32m'
 RED='\033[0;31m'
 NOC='\033[0m' # No Color
-echo_info(){
-    printf "\n${BLU}%s${NOC}" "$1"
-}
 echo_step(){
     printf "\n${BLU}>>>>>>> %s${NOC}\n" "$1"
 }
-echo_sub_step(){
-    printf "\n${BLU}>>> %s${NOC}\n" "$1"
-}
-
-echo_step_completed(){
-    printf "${GRN} [✔]${NOC}"
-}
-
 echo_success(){
     printf "\n${GRN}%s${NOC}\n" "$1"
 }
-echo_warn(){
-    printf "\n${YLW}%s${NOC}" "$1"
-}
 echo_error(){
-    printf "\n${RED}%s${NOC}" "$1"
+    printf "\n${RED}%s${NOC}\n" "$1"
     exit 1
 }
 
-
-# The name of your provider. Many provider Makefiles override this value.
 PACKAGE_NAME="provider-sonarqube"
-
-
-# ------------------------------
 projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../.. && pwd )"
 
-# get the build environment variables from the special build.vars target in the main makefile
-eval $(make --no-print-directory -C ${projectdir} build.vars)
+# Pull tool paths and project metadata from the build submodule.
+eval "$(make --no-print-directory -C "${projectdir}" build.vars)"
 
-# ------------------------------
+# build/makelib/local.xpkg.mk and controlplane.mk default to KIND_CLUSTER_NAME=local-dev.
+# Use a build-id-tagged name so concurrent runs (CI parallelism) do not collide.
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-${BUILD_REGISTRY:-build}-inttests}"
+export KIND_CLUSTER_NAME
 
-SAFEHOSTARCH="${SAFEHOSTARCH:-amd64}"
-BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
-PACKAGE_IMAGE="crossplane.io/inttests/${PROJECT_NAME}:${VERSION}"
-CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${SAFEHOSTARCH}"
-
-version_tag="$(cat ${projectdir}/_output/version)"
-# tag as latest version to load into kind cluster
-PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}-controller:${VERSION}"
-K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
-
-CROSSPLANE_NAMESPACE="crossplane-system"
-
-# cleanup on exit
-if [ "$skipcleanup" != true ]; then
-  function cleanup {
-    echo_step "Cleaning up..."
-    export KUBECONFIG=
-    "${KIND}" delete cluster --name="${K8S_CLUSTER}"
+# cleanup on exit unless skipcleanup is set.
+if [ "${skipcleanup}" != "true" ]; then
+  cleanup() {
+    echo_step "cleaning up controlplane"
+    "${KIND}" delete cluster --name="${KIND_CLUSTER_NAME}" || true
   }
-
   trap cleanup EXIT
 fi
 
-# setup package cache
-echo_step "setting up local package cache"
-CACHE_PATH="${projectdir}/.work/inttest-package-cache"
-mkdir -p "${CACHE_PATH}"
-echo "created cache dir at ${CACHE_PATH}"
-docker tag "${BUILD_IMAGE}" "${PACKAGE_IMAGE}"
-"${UP}" xpkg xp-extract --from-daemon "${PACKAGE_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.gz" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.gz"
+if [ ! -f "${OUTPUT_DIR}/xpkg/${PLATFORM}/${PACKAGE_NAME}-${VERSION}.xpkg" ]; then
+    echo_error "xpkg not built — run 'make build' first"
+fi
 
-# create kind cluster with extra mounts
-KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
-echo_step "creating k8s cluster using kind ${KIND_VERSION} and node image ${KIND_NODE_IMAGE}"
-KIND_CONFIG="$( cat <<EOF
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-  extraMounts:
-  - hostPath: "${CACHE_PATH}/"
-    containerPath: /cache
-EOF
-)"
-echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --image="${KIND_NODE_IMAGE}" --config=-
+echo_step "creating kind controlplane and installing crossplane"
+make -C "${projectdir}" controlplane.up
 
-# tag controller image and load it into kind cluster
-docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"
-"${KIND}" load docker-image "${PACKAGE_CONTROLLER_IMAGE}" --name="${K8S_CLUSTER}"
+echo_step "loading SonarQube image into kind cluster"
+docker pull docker.io/library/sonarqube:community
+"${KIND}" load docker-image docker.io/library/sonarqube:community --name="${KIND_CLUSTER_NAME}"
 
-echo_step "create crossplane-system namespace"
-"${KUBECTL}" create ns crossplane-system
+echo_step "deploying ${PACKAGE_NAME} provider package"
+# local.xpkg.deploy.provider.<name> patches Crossplane with a dev sidecar,
+# extracts each xpkg into the cache under the cache key Crossplane >=2.2
+# expects (xpkg.crossplane.internal/dev/<name>@<digest>), kubectl-cps the
+# cache into the sidecar, loads the controller image into kind, and
+# creates a Provider + DeploymentRuntimeConfig wired to the local image.
+# See build/makelib/local.xpkg.mk.
+make -C "${projectdir}" "local.xpkg.deploy.provider.${PACKAGE_NAME}"
 
-echo_step "create persistent volume and claim for mounting package-cache"
-PV_YAML="$( cat <<EOF
-apiVersion: v1
-kind: PersistentVolume
+echo_step "granting provider service account permission to watch CRDs"
+# The package declares the `safe-start` capability, which makes each
+# controller wait for its CRD before starting. Crossplane's auto-generated
+# system ClusterRole for the provider does not include CRD list/watch, so
+# the safe-start gate would otherwise crash-loop the provider with a
+# Forbidden error from controller-runtime's CRD informer. Bind the
+# auto-created provider ServiceAccount to a small extra ClusterRole that
+# closes that gap.
+echo "waiting for provider service account to be created"
+provider_sa=""
+for _ in $(seq 1 60); do
+    provider_sa="$("${KUBECTL}" get sa -n crossplane-system -o name 2>/dev/null | grep "${PACKAGE_NAME}" | head -1 | sed 's|^serviceaccount/||')"
+    if [ -n "${provider_sa}" ]; then
+        break
+    fi
+    sleep 2
+done
+if [ -z "${provider_sa}" ]; then
+    echo_error "provider service account did not appear within 120s"
+fi
+echo "binding ServiceAccount ${provider_sa} to CRD watch role"
+"${KUBECTL}" apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: package-cache
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage: 5Mi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: "/cache"
-EOF
-)"
-echo "${PV_YAML}" | "${KUBECTL}" create -f -
-
-PVC_YAML="$( cat <<EOF
-apiVersion: v1
-kind: PersistentVolumeClaim
+  name: ${PACKAGE_NAME}-crd-watcher
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: package-cache
-  namespace: crossplane-system
-spec:
-  accessModes:
-    - ReadWriteOnce
-  volumeName: package-cache
-  storageClassName: manual
-  resources:
-    requests:
-      storage: 1Mi
+  name: ${PACKAGE_NAME}-crd-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ${PACKAGE_NAME}-crd-watcher
+subjects:
+  - kind: ServiceAccount
+    name: ${provider_sa}
+    namespace: crossplane-system
 EOF
-)"
-echo "${PVC_YAML}" | "${KUBECTL}" create -f -
 
-# install crossplane from stable channel
-echo_step "installing crossplane from stable channel"
-"${HELM3}" repo add crossplane-stable https://charts.crossplane.io/stable/
-chart_version="$("${HELM3}" search repo crossplane-stable/crossplane | awk 'FNR == 2 {print $2}')"
-echo_info "using crossplane version ${chart_version}"
-echo
-# we replace empty dir with our PVC so that the /cache dir in the kind node
-# container is exposed to the crossplane pod
-"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
-
-# ----------- integration tests
-echo_step "--- INTEGRATION TESTS ---"
-
-# install package
-echo_step "installing ${PROJECT_NAME} into \"${CROSSPLANE_NAMESPACE}\" namespace"
-
-INSTALL_YAML="$( cat <<EOF
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: "${PACKAGE_NAME}"
-spec:
-  package: "${PACKAGE_NAME}"
-  packagePullPolicy: Never
-EOF
-)"
-
-echo "${INSTALL_YAML}" | "${KUBECTL}" apply -f -
-
-# printing the cache dir contents can be useful for troubleshooting failures
-echo_step "check kind node cache dir contents"
-docker exec "${K8S_CLUSTER}-control-plane" ls -la /cache
-
-echo_step "waiting for provider to be installed"
-
-kubectl wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=180s
+echo_step "waiting for provider to become healthy"
+"${KUBECTL}" wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=300s
 
 echo_step "configuring in-cluster SonarQube and ClusterProviderConfig"
 KUBECTL="${KUBECTL}" "${projectdir}/cluster/local/sonarqube_setup.sh"
@@ -196,22 +128,5 @@ kill "${e2e_pf_pid}" 2>/dev/null || true
 if [ "${e2e_status}" -ne 0 ]; then
   echo_error "e2e Go suite failed (exit ${e2e_status})"
 fi
-
-echo_step "uninstalling ${PROJECT_NAME}"
-
-echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -
-
-# check pods deleted
-timeout=60
-current=0
-step=3
-while [[ $(kubectl get providerrevision.pkg.crossplane.io -o name | wc -l) != "0" ]]; do
-  echo "waiting for provider to be deleted for another $step seconds"
-  current=$current+$step
-  if ! [[ $timeout > $current ]]; then
-    echo_error "timeout of ${timeout}s has been reached"
-  fi
-  sleep $step;
-done
 
 echo_success "Integration tests succeeded!"


### PR DESCRIPTION
### Description of your changes

This PR adds a new GitHub Actions job that runs e2e tests on approval on every pull request, after lint and unit-tests pass. The job skips automatically for documentation-only changes (via the existing detect-noop gate), reuses the Go build + module cache pattern used by the other jobs, and has a 30-minute timeout.

- a post-step collects `kubectl get/describe` and pod logs for sonarqube, the provider, and crossplane into _output/e2e-logs/ and uploads them as the `e2e-logs` artifact on failure.
- An always()-step tears down the kind cluster at the end.

Update CONTRIBUTING.md to mention that the suite now runs in CI and to recommend a local `make e2e.run` before pushing infra changes.

Closes #68 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.

### How has this code been tested

I have:

- [ ] Ensured the CI runs and provides the expected results
- [ ] Checked and set up guard rails against deadlocks

[contribution process]: https://git.io/fj2m9
