### PR TITLE
test(e2e): add integrations e2e tests

### DIFF
--- a/internal/clients/common/kubernetes_test.go
+++ b/internal/clients/common/kubernetes_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -137,7 +138,7 @@ func TestGetTokenValueFromSecret(t *testing.T) {
 					Key: "token",
 				},
 			},
-			want:    strPtr("my-token-value"),
+			want:    ptr.To("my-token-value"),
 			wantErr: false,
 		},
 	}
@@ -231,7 +232,7 @@ func TestGetTokenValueFromLocalSecret(t *testing.T) {
 					Key: "token",
 				},
 			},
-			want:    strPtr("local-token-value"),
+			want:    ptr.To("local-token-value"),
 			wantErr: false,
 		},
 		"SecretNotFoundReturnsError": {
@@ -292,11 +293,6 @@ func TestGetTokenValueFromLocalSecret(t *testing.T) {
 			}
 		})
 	}
-}
-
-// strPtr returns a pointer to the given string.
-func strPtr(s string) *string {
-	return &s
 }
 
 // containsString checks if a string contains a substring.

--- a/internal/test/e2e/iam/group_test.go
+++ b/internal/test/e2e/iam/group_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package iam_test
 
 import (
@@ -25,6 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -54,7 +55,7 @@ func TestGroupCRUD(t *testing.T) {
 			},
 			ForProvider: iamv1alpha1.GroupParameters{
 				Name:        groupName,
-				Description: stringPtr("E2E-managed group"),
+				Description: ptr.To("E2E-managed group"),
 				Permissions: &wantPerms,
 			},
 		},

--- a/internal/test/e2e/iam/helpers_test.go
+++ b/internal/test/e2e/iam/helpers_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package iam_test
 
 import (
@@ -23,12 +23,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// stringPtr returns a pointer to the supplied string.
-func stringPtr(s string) *string { return &s }
-
-// boolPtr returns a pointer to the supplied bool.
-func boolPtr(b bool) *bool { return &b }
 
 // kubeKey is a terse alias for client.ObjectKeyFromObject.
 func kubeKey(obj client.Object) client.ObjectKey {

--- a/internal/test/e2e/iam/permissionstemplate_test.go
+++ b/internal/test/e2e/iam/permissionstemplate_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package iam_test
 
 import (
@@ -25,6 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -53,8 +54,8 @@ func TestPermissionsTemplateCRUD(t *testing.T) {
 			},
 			ForProvider: iamv1alpha1.PermissionsTemplateParameters{
 				Name:              templateName,
-				Description:       stringPtr("E2E-managed permissions template"),
-				ProjectKeyPattern: stringPtr(keyPattern),
+				Description:       ptr.To("E2E-managed permissions template"),
+				ProjectKeyPattern: ptr.To(keyPattern),
 			},
 		},
 	}

--- a/internal/test/e2e/iam/user_test.go
+++ b/internal/test/e2e/iam/user_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package iam_test
 
 import (
@@ -25,9 +25,10 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	iamv1alpha1 "github.com/crossplane/provider-sonarqube/apis/iam/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -73,8 +74,8 @@ func TestUserCRUD(t *testing.T) {
 			ForProvider: iamv1alpha1.UserParameters{
 				Login: userLogin,
 				Name:  userName,
-				Email: stringPtr(userEmail),
-				Local: boolPtr(true),
+				Email: ptr.To(userEmail),
+				Local: ptr.To(true),
 				PasswordSecretRef: &xpv1.SecretKeySelector{
 					Key: secretKey,
 					SecretReference: xpv1.SecretReference{
@@ -84,7 +85,7 @@ func TestUserCRUD(t *testing.T) {
 				},
 				// Anonymise on delete so re-creating with the same login
 				// after a previous run leaves no observable trace.
-				Anonymize: boolPtr(true),
+				Anonymize: ptr.To(true),
 			},
 		},
 	}

--- a/internal/test/e2e/instance/project_test.go
+++ b/internal/test/e2e/instance/project_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package instance_test
 
 import (
@@ -25,6 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -56,14 +57,14 @@ func TestProjectCRUD(t *testing.T) {
 			ForProvider: instancev1alpha1.ProjectParameters{
 				Key:           projKey,
 				Name:          projName,
-				Visibility:    stringPtr(visPublic),
-				DefaultBranch: stringPtr("main"),
+				Visibility:    ptr.To(visPublic),
+				DefaultBranch: ptr.To("main"),
 				Tags:          &[]string{"crossplane", "e2e"},
 				// Pin to the built-in "Sonar way" gate. Leaving this unset
 				// causes Crossplane's reference resolver to issue a server
 				// side apply with qualityGateName="" which fails the field's
 				// MinLength=1 CRD validation.
-				QualityGateName: stringPtr("Sonar way"),
+				QualityGateName: ptr.To("Sonar way"),
 			},
 		},
 	}

--- a/internal/test/e2e/instance/qualitygate_test.go
+++ b/internal/test/e2e/instance/qualitygate_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package instance_test
 
 import (
@@ -27,6 +27,7 @@ import (
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -56,7 +57,7 @@ func TestQualityGateCRUD(t *testing.T) {
 			ForProvider: instancev1alpha1.QualityGateParameters{
 				Name: qgName,
 				Conditions: []instancev1alpha1.QualityGateConditionParameters{
-					{Metric: "blocker_violations", Op: stringPtr("GT"), Error: "0"},
+					{Metric: "blocker_violations", Op: ptr.To("GT"), Error: "0"},
 				},
 			},
 		},
@@ -104,7 +105,7 @@ func TestQualityGateInvalidMetric(t *testing.T) {
 			ForProvider: instancev1alpha1.QualityGateParameters{
 				Name: qgName,
 				Conditions: []instancev1alpha1.QualityGateConditionParameters{
-					{Metric: "not_a_real_metric", Op: stringPtr("GT"), Error: "0"},
+					{Metric: "not_a_real_metric", Op: ptr.To("GT"), Error: "0"},
 				},
 			},
 		},

--- a/internal/test/e2e/instance/qualityprofile_test.go
+++ b/internal/test/e2e/instance/qualityprofile_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package instance_test
 
 import (
@@ -25,6 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -57,7 +58,7 @@ func TestQualityProfileCRUD(t *testing.T) {
 			ForProvider: instancev1alpha1.QualityProfileParameters{
 				Name:     qpName,
 				Language: qpLang,
-				Default:  boolPtr(false),
+				Default:  ptr.To(false),
 			},
 		},
 	}

--- a/internal/test/e2e/instance/rule_test.go
+++ b/internal/test/e2e/instance/rule_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package instance_test
 
 import (
@@ -26,6 +26,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -62,8 +63,8 @@ func TestRuleCRUD(t *testing.T) {
 				Name:                ruleName,
 				TemplateKey:         templateKey,
 				MarkdownDescription: markdown,
-				Status:              stringPtr("READY"),
-				Type:                stringPtr("CODE_SMELL"),
+				Status:              ptr.To("READY"),
+				Type:                ptr.To("CODE_SMELL"),
 			},
 		},
 	}

--- a/internal/test/e2e/instance/settings_test.go
+++ b/internal/test/e2e/instance/settings_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026 The Crossplane Authors.
 
@@ -14,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build e2e
-
 package instance_test
 
 import (
@@ -25,6 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	instancev1alpha1 "github.com/crossplane/provider-sonarqube/apis/instance/v1alpha1"
 	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
@@ -55,7 +56,7 @@ func TestSettingsGlobalScalar(t *testing.T) {
 			},
 			ForProvider: instancev1alpha1.SettingsParameters{
 				Settings: map[string]instancev1alpha1.SettingParameters{
-					settingKey: {Value: stringPtr(settingValue)},
+					settingKey: {Value: ptr.To(settingValue)},
 				},
 			},
 		},

--- a/internal/test/e2e/integration/alm_github_test.go
+++ b/internal/test/e2e/integration/alm_github_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	integrationv1alpha1 "github.com/crossplane/provider-sonarqube/apis/integration/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestALMGitHubCRUD creates an ALMGitHub resource, waits for Ready, then
+// verifies SonarQube reports a matching GitHub ALM definition with the
+// expected key, URL, AppID and ClientID.
+func TestALMGitHubCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName          = "e2e-almgithub-crud"
+		almKey          = "e2e-almgithub-crud"
+		almURL          = "https://api.github.com"
+		almAppID        = "123456"
+		almClientID     = "Iv1.e2etest123456"
+		clientSecretRef = "e2e-almgithub-crud-client-secret"
+		privateKeyRef   = "e2e-almgithub-crud-private-key"
+		connSecretName  = "e2e-almgithub-crud-connection"
+	)
+
+	clientSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: clientSecretRef, Namespace: "default"},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{"clientSecret": "e2e-fake-client-secret"},
+	}
+	privateKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: privateKeyRef, Namespace: "default"},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{"privateKey": "e2e-fake-private-key"},
+	}
+
+	for _, s := range []*corev1.Secret{clientSecret, privateKey} {
+		if err := f.Kube.Create(context.Background(), s); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("creating secret %s: %v", s.Name, err)
+		}
+		s := s
+		t.Cleanup(func() {
+			_ = f.Kube.Delete(context.Background(), s)
+		})
+	}
+
+	alm := &integrationv1alpha1.ALMGitHub{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: integrationv1alpha1.ALMGitHubSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				WriteConnectionSecretToReference: &xpv1.LocalSecretReference{Name: connSecretName},
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: integrationv1alpha1.ALMGitHubParameters{
+				Key:      almKey,
+				URL:      almURL,
+				AppID:    almAppID,
+				ClientID: almClientID,
+				ClientSecretRef: &xpv1.LocalSecretKeySelector{
+					LocalSecretReference: xpv1.LocalSecretReference{Name: clientSecretRef},
+					Key:                  "clientSecret",
+				},
+				PrivateKeyRef: &xpv1.LocalSecretKeySelector{
+					LocalSecretReference: xpv1.LocalSecretReference{Name: privateKeyRef},
+					Key:                  "privateKey",
+				},
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, alm, 2*time.Minute)
+	e2e.AssertReady(t, alm)
+	e2e.AssertSynced(t, alm)
+	e2e.AssertExternalName(t, alm, almKey)
+
+	got, err := f.FindALMGitHubDefinitionByKey(almKey)
+	if err != nil {
+		t.Fatalf("fetching GitHub ALM definition: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GitHub ALM definition %q not found in SonarQube", almKey)
+	}
+	if got.URL != almURL {
+		t.Errorf("ALM URL = %q, want %q", got.URL, almURL)
+	}
+	if got.AppID != almAppID {
+		t.Errorf("ALM AppID = %q, want %q", got.AppID, almAppID)
+	}
+	if got.ClientID != almClientID {
+		t.Errorf("ALM ClientID = %q, want %q", got.ClientID, almClientID)
+	}
+}

--- a/internal/test/e2e/integration/alm_gitlab_test.go
+++ b/internal/test/e2e/integration/alm_gitlab_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	integrationv1alpha1 "github.com/crossplane/provider-sonarqube/apis/integration/v1alpha1"
+	"github.com/crossplane/provider-sonarqube/internal/test/e2e"
+)
+
+// TestALMGitLabCRUD creates an ALMGitLab resource, waits for Ready, then
+// verifies SonarQube reports a matching GitLab ALM definition with the
+// expected key and URL.
+func TestALMGitLabCRUD(t *testing.T) {
+	t.Parallel()
+
+	f := e2e.New(t)
+	const (
+		crName        = "e2e-almgitlab-crud"
+		almKey        = "e2e-almgitlab-crud"
+		almURL        = "https://gitlab.example.com"
+		secretName    = "e2e-almgitlab-crud-token"
+		secretKey     = "token"
+		connSecretName = "e2e-almgitlab-crud-connection"
+	)
+
+	patSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{secretKey: "e2e-fake-gitlab-pat"},
+	}
+	if err := f.Kube.Create(context.Background(), patSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating PAT secret: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = f.Kube.Delete(context.Background(), patSecret)
+	})
+
+	alm := &integrationv1alpha1.ALMGitLab{
+		ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: "default"},
+		Spec: integrationv1alpha1.ALMGitLabSpec{
+			ManagedResourceSpec: xpv2.ManagedResourceSpec{
+				WriteConnectionSecretToReference: &xpv1.LocalSecretReference{Name: connSecretName},
+				ProviderConfigReference: &xpv1.ProviderConfigReference{
+					Kind: "ClusterProviderConfig",
+					Name: f.ProviderConfigName,
+				},
+			},
+			ForProvider: integrationv1alpha1.ALMGitLabParameters{
+				ALMCommonParameters: integrationv1alpha1.ALMCommonParameters{
+					Key: almKey,
+					URL: almURL,
+					PersonalAccessTokenSecretRef: &xpv1.LocalSecretKeySelector{
+						LocalSecretReference: xpv1.LocalSecretReference{Name: secretName},
+						Key:                  secretKey,
+					},
+				},
+			},
+		},
+	}
+
+	f.CreateAndWaitForReady(t, alm, 2*time.Minute)
+	e2e.AssertReady(t, alm)
+	e2e.AssertSynced(t, alm)
+	e2e.AssertExternalName(t, alm, almKey)
+
+	got, err := f.FindALMGitLabDefinitionByKey(almKey)
+	if err != nil {
+		t.Fatalf("fetching GitLab ALM definition: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GitLab ALM definition %q not found in SonarQube", almKey)
+	}
+	if got.URL != almURL {
+		t.Errorf("ALM URL = %q, want %q", got.URL, almURL)
+	}
+}

--- a/internal/test/e2e/integration/helpers_test.go
+++ b/internal/test/e2e/integration/helpers_test.go
@@ -16,14 +16,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package instance_test
+package integration_test
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// kubeKey is a terse alias for client.ObjectKeyFromObject to keep the
-// polling loops in the individual test files readable.
+// kubeKey is a terse alias for client.ObjectKeyFromObject.
 func kubeKey(obj client.Object) client.ObjectKey {
 	return client.ObjectKeyFromObject(obj)
 }

--- a/internal/test/e2e/sonarqube.go
+++ b/internal/test/e2e/sonarqube.go
@@ -194,3 +194,35 @@ func (f *Framework) GroupPermissions(groupName string) ([]string, error) {
 	}
 	return []string{}, nil
 }
+
+// FindALMGitLabDefinitionByKey returns the GitLab ALM setting definition
+// whose key exactly matches key, or (nil, nil) if no such definition exists.
+func (f *Framework) FindALMGitLabDefinitionByKey(key string) (*sonar.GitlabDefinition, error) {
+	res, resp, err := f.Sonar.AlmSettings.ListDefinitions()
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Gitlab {
+		if res.Gitlab[i].Key == key {
+			return &res.Gitlab[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional: absence of definition is the natural "not yet created" sentinel
+}
+
+// FindALMGitHubDefinitionByKey returns the GitHub ALM setting definition
+// whose key exactly matches key, or (nil, nil) if no such definition exists.
+func (f *Framework) FindALMGitHubDefinitionByKey(key string) (*sonar.GithubDefinition, error) {
+	res, resp, err := f.Sonar.AlmSettings.ListDefinitions()
+	defer helpers.CloseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	for i := range res.Github {
+		if res.Github[i].Key == key {
+			return &res.Github[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // intentional
+}


### PR DESCRIPTION
### Description of your changes

This PR adds e2e tests for existing Integration group resources (ALMGitLab & ALMGitHub).

It also removes useless helper functions.

Closes #69 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Followed the git conventional commit message format.

### How has this code been tested

I have:

- [x] Successfully passed the new e2e tests

[contribution process]: https://git.io/fj2m9
